### PR TITLE
[TECH] Ajout de la github action automerge (PIX-5029).

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,23 @@
+name: automerge check
+
+on:
+  pull_request:
+    types:
+      - labeled
+  check_suite:
+    types:
+      - completed
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: automerge
+        uses: pascalgn/automerge-action@v0.15.3
+        env:
+          GITHUB_TOKEN: '${{ secrets.PIX_SERVICE_ACTIONS_TOKEN }}'
+          MERGE_LABELS: ':rocket: Ready to Merge,!:warning: Blocked,!:earth_africa: i18n needed,!:busts_in_silhouette: Panel Review Needed,!Development in progress,!:eyes: Design Review Needed,!:eyes: Func Review Needed,!:eyes: Tech Review Needed'
+          MERGE_COMMIT_MESSAGE: pull-request-title
+          UPDATE_LABELS: ':rocket: Ready to Merge'
+          UPDATE_METHOD: rebase
+          MERGE_FORKS: 'false'
+          MERGE_REQUIRED_APPROVALS: 1


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, nous ne pouvons merger que manuellement à partir du bouton de github. Nous souhaitons pouvoir le faire grâce au label Ready to merge, de la même manière que sur les autres repos de 1024pix.

## :robot: Solution
Mettre en place la github action auto-merge

## :rainbow: Remarques
N/A

## :100: Pour tester
Merger cette PR avec le label 'Ready to merge'