### PR TITLE
[BUGFIX] Accéder à un tutoriel sans devoir passer par la page d'accueil. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist
 .idea
 .editorconfig
 .vscode/*
+nginx.conf

--- a/README.md
+++ b/README.md
@@ -41,3 +41,11 @@ Exemples :
 
 - components/AppFooter.vue
 - components/MediaPlayer.vue
+
+## NGINX
+
+```shell
+npm run build:site
+
+PORT=80 erb servers.conf.erb > nginx.conf && docker-compose up
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3'
+services:
+  nginx:
+    image: nginx:latest
+    container_name: production_tutos_nginx
+    tmpfs:
+      - /etc/nginx/logs
+    volumes:
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf
+      - ./dist:/app/dist
+    ports:
+      - 80:80

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,1 +1,0 @@
-root /app/dist;

--- a/servers.conf.erb
+++ b/servers.conf.erb
@@ -1,0 +1,25 @@
+log_format keyvalue
+  'method=$request_method'
+  ' path="$request_uri"'
+  ' host=$host'
+  ' request_id=$http_x_request_id'
+  ' from="$remote_addr"'
+  ' protocol=$scheme'
+  ' status=$status'
+  ' duration=${request_time}s'
+  ' bytes=$bytes_sent'
+  ' referer="$http_referer"'
+  ' user_agent="$http_user_agent"';
+
+# In order to avoid logging access twice per request
+# it is necessary to turn off the top-level (e.g. http) buildpack default access_log
+# as we are about to override it in the server directive here below
+access_log off;
+
+port_in_redirect off;
+
+server {
+  access_log logs/access.log keyvalue;
+  listen <%= ENV['PORT'] %>;
+  root /app/dist;
+}


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, nous ne pouvons pas nous rendre directement sur un tutoriel car la redirection nginx ne fonctionne pas correctement. 

## :robot: Solution
- Ajout d'un serveur écoutant sur le PORT passé en variable d'environnement
- Ajout de l'option : `port_in_redirect off;` qui permet le bon fonctionnement de la redirection.
- Ajout des access_log dans le bon format pour Datadog

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Se rendre sur : https://pix-tutos-review-pr13.osc-fr1.scalingo.io/la-certification