### PR TITLE
[FEATURE] Ajout d'une page 404 custom (PIX-5074).

### DIFF
--- a/layouts/error.vue
+++ b/layouts/error.vue
@@ -2,9 +2,9 @@
   <div class="error">
     <a href="https://pix.fr/">
       <img
-        class="error__logo"
-        src="~/assets/images/pix-logo.svg"
-        alt="Lien pour revenir à l'accueil"
+          class="error__logo"
+          src="../assets/images/pix-logo.svg"
+          alt="Lien pour revenir à l'accueil"
       />
     </a>
     <p class="error__message">{{ error.message }}</p>
@@ -13,6 +13,7 @@
 
 <script>
 export default {
+  layout: 'simple',
   props: {
     error: {
       type: Object,
@@ -22,21 +23,20 @@ export default {
   head() {
     return {
       title: 'Erreur | Pix-tutos',
-    };
+    }
   },
-};
+}
 </script>
 
 <style lang="scss">
 .error {
   width: 300px;
-  margin-left: auto;
-  margin-right: auto;
+  padding-top: 48px;
+  margin: auto;
 
   &__logo {
     display: block;
-    margin-left: auto;
-    margin-right: auto;
+    margin: auto;
   }
 
   &__message {

--- a/layouts/error.vue
+++ b/layouts/error.vue
@@ -1,0 +1,46 @@
+<template>
+  <div class="error">
+    <a href="https://pix.fr/">
+      <img
+        class="error__logo"
+        src="~/assets/images/pix-logo.svg"
+        alt="Lien pour revenir à l'accueil"
+      />
+    </a>
+    <p class="error__message">{{ error.message }}</p>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    error: {
+      type: Object,
+      default: null,
+    },
+  },
+  head() {
+    return {
+      title: 'Erreur | Pix-tutos',
+    };
+  },
+};
+</script>
+
+<style lang="scss">
+.error {
+  width: 300px;
+  margin-left: auto;
+  margin-right: auto;
+
+  &__logo {
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  &__message {
+    text-align: center;
+  }
+}
+</style>

--- a/layouts/simple.vue
+++ b/layouts/simple.vue
@@ -1,0 +1,11 @@
+<template>
+  <div id="app" class="app-viewport">
+    <nuxt />
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'Simple',
+}
+</script>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -3,6 +3,9 @@ import isSeoIndexingEnabled from './services/is-seo-indexing-enabled';
 export default {
   target: 'static',
   components: true,
+  generate: {
+    fallback: '404.html'
+  },
   head: {
     title: 'Pix+Edu tutos',
     htmlAttrs: {

--- a/servers.conf.erb
+++ b/servers.conf.erb
@@ -22,4 +22,6 @@ server {
   access_log logs/access.log keyvalue;
   listen <%= ENV['PORT'] %>;
   root /app/dist;
+
+  error_page 400 401 403 404 418 500 502 503 504 /404.html;
 }


### PR DESCRIPTION
## :unicorn: Problème

Nous utilisons à l'heure actuelle la page d'erreur Nginx en cas de 404, et voudrions utiliser une page custom à la place.

## :robot: Solution

Modification de la config Nuxt pour renvoyer la page `404.html` en cas d'erreur.
Ajout d'une page `error.vue` dans le dossier `layout` de Nuxt.

## :rainbow: Remarques

Garde t-on la redirection vers `pix.fr` comme sur `Pix-site` sachant que celle-ci peut déjà se faire via la barre de navigation ?

Le style est très "brut", si vous avez des pistes d'amélioration, je suis tout ouïe.

## :100: Pour tester

Sur la RA, vérifier que la page rendue est bien la page 404 nouvellement créée en cas d'URL invalide.