### PR TITLE
[FEATURE] Ajoute les boutons de connection et d'inscription si absence de query string `?c` (PIX-5119)

### DIFF
--- a/components/PixHeader.vue
+++ b/components/PixHeader.vue
@@ -20,7 +20,7 @@
         </a>
       </div>
 
-      <div v-if="!isConnected" class="main-header__actions">
+      <div v-if="!hideActions" class="main-header__actions">
         <PixButtonLink
           href="https://app.pix.fr/connexion"
           background-color="transparent-light"
@@ -38,9 +38,9 @@
 <script>
 export default {
   props: {
-    isConnected: {
+    hideActions: {
       type: Boolean,
-      default: false,
+      default: true,
     },
   },
 };

--- a/components/PixHeader.vue
+++ b/components/PixHeader.vue
@@ -1,0 +1,77 @@
+<template>
+  <header class="main-header">
+    <div class="main-header__container">
+      <div class="main-header__logos">
+        <img
+          src="~/assets/images/marianne-logo.svg"
+          class="main-header__logo"
+          alt=""
+        />
+        <a
+          class="main-header__link"
+          href="https://pix.fr"
+          title="Site officiel Pix.fr"
+        >
+          <img
+            src="~/assets/images/pix-logo.svg"
+            class="main-header__logo"
+            alt="Pix"
+          />
+        </a>
+      </div>
+
+      <div v-if="!isConnected" class="main-header__actions">
+        <PixButtonLink
+          href="https://app.pix.fr/connexion"
+          background-color="transparent-light"
+        >
+          Se connecter
+        </PixButtonLink>
+        <PixButtonLink href="https://app.pix.fr/inscription">
+          S'inscrire
+        </PixButtonLink>
+      </div>
+    </div>
+  </header>
+</template>
+
+<script>
+export default {
+  props: {
+    isConnected: {
+      type: Boolean,
+      default: false,
+    },
+  },
+};
+</script>
+
+<style lang="scss">
+.main-header {
+  background-color: white;
+  box-shadow: $box-shadow-xs;
+}
+
+.main-header__container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  padding: 1rem;
+  max-width: 1280px;
+  margin: 0 auto;
+
+  > * {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 1.5rem;
+  }
+}
+
+.main-header__logo {
+  display: block;
+  height: 60px;
+}
+</style>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -2,22 +2,35 @@
   <div id="app" class="app-viewport">
     <header class="main-header">
       <div class="main-header__container">
-        <img
-          src="~/assets/images/marianne-logo.svg"
-          class="main-header__logo"
-          alt=""
-        />
-        <a
-          class="main-header__link"
-          href="https://pix.fr"
-          title="Site officiel Pix.fr"
-        >
+        <div class="main-header__logos">
           <img
-            src="~/assets/images/pix-logo.svg"
+            src="~/assets/images/marianne-logo.svg"
             class="main-header__logo"
-            alt="Pix"
+            alt=""
           />
-        </a>
+          <a
+            class="main-header__link"
+            href="https://pix.fr"
+            title="Site officiel Pix.fr"
+          >
+            <img
+              src="~/assets/images/pix-logo.svg"
+              class="main-header__logo"
+              alt="Pix"
+            />
+          </a>
+        </div>
+        <div v-if="!isConnected" class="main-header__actions">
+          <PixButtonLink
+            href="https://app.pix.fr/connexion"
+            background-color="transparent-light"
+          >
+            Se connecter
+          </PixButtonLink>
+          <PixButtonLink href="https://app.pix.fr/inscription">
+            S'inscrire
+          </PixButtonLink>
+        </div>
       </div>
     </header>
     <main role="main" class="main-container">
@@ -25,6 +38,24 @@
     </main>
   </div>
 </template>
+
+<script>
+export default {
+  data() {
+    return {
+      isConnected: false,
+    };
+  },
+
+  // The `mounted` lifecycle hook is called client side
+  // https://nuxtjs.org/docs/concepts/nuxt-lifecycle/#client
+  mounted() {
+    if (location.search.includes('connecte')) {
+      this.isConnected = true;
+    }
+  },
+};
+</script>
 
 <style lang="scss">
 #app {
@@ -41,18 +72,24 @@
 .main-header__container {
   display: flex;
   align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 1.5rem;
   padding: 1rem;
   max-width: 1280px;
   margin: 0 auto;
+
+  > * {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 1.5rem;
+  }
 }
 
 .main-header__logo {
   display: block;
   height: 60px;
-}
-
-.main-header__link {
-  margin-left: 1.5rem;
 }
 
 .main-container {

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,38 +1,6 @@
 <template>
   <div id="app" class="app-viewport">
-    <header class="main-header">
-      <div class="main-header__container">
-        <div class="main-header__logos">
-          <img
-            src="~/assets/images/marianne-logo.svg"
-            class="main-header__logo"
-            alt=""
-          />
-          <a
-            class="main-header__link"
-            href="https://pix.fr"
-            title="Site officiel Pix.fr"
-          >
-            <img
-              src="~/assets/images/pix-logo.svg"
-              class="main-header__logo"
-              alt="Pix"
-            />
-          </a>
-        </div>
-        <div v-if="!isConnected" class="main-header__actions">
-          <PixButtonLink
-            href="https://app.pix.fr/connexion"
-            background-color="transparent-light"
-          >
-            Se connecter
-          </PixButtonLink>
-          <PixButtonLink href="https://app.pix.fr/inscription">
-            S'inscrire
-          </PixButtonLink>
-        </div>
-      </div>
-    </header>
+    <PixHeader :is-connected="isConnected" />
     <main role="main" class="main-container">
       <nuxt />
     </main>
@@ -62,34 +30,6 @@ export default {
   min-height: 100vh;
   font-family: $open-sans;
   background-color: $background-light;
-}
-
-.main-header {
-  background-color: white;
-  box-shadow: $box-shadow-xs;
-}
-
-.main-header__container {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  flex-wrap: wrap;
-  gap: 1.5rem;
-  padding: 1rem;
-  max-width: 1280px;
-  margin: 0 auto;
-
-  > * {
-    display: flex;
-    align-items: center;
-    flex-wrap: wrap;
-    gap: 1.5rem;
-  }
-}
-
-.main-header__logo {
-  display: block;
-  height: 60px;
 }
 
 .main-container {

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,6 +1,6 @@
 <template>
   <div id="app" class="app-viewport">
-    <PixHeader :is-connected="isConnected" />
+    <PixHeader :hide-actions="shouldDisplayActions" />
     <main role="main" class="main-container">
       <nuxt />
     </main>
@@ -11,16 +11,21 @@
 export default {
   data() {
     return {
-      isConnected: false,
+      isConnected: undefined,
     };
+  },
+
+  computed: {
+    // Hide actions while loading to avoid layout shift
+    shouldDisplayActions() {
+      return this.isConnected ?? true;
+    },
   },
 
   // The `mounted` lifecycle hook is called client side
   // https://nuxtjs.org/docs/concepts/nuxt-lifecycle/#client
   mounted() {
-    if (location.search.includes('connecte')) {
-      this.isConnected = true;
-    }
+    this.isConnected = location.search.startsWith('?c');
   },
 };
 </script>


### PR DESCRIPTION
## :unicorn: Problème
Il n'y a pour le moment pas de lien pour aller vers Pix depuis pix-tutos.

## :robot: Solution
Ajouter des liens vers la page de connexion et d'inscription si une query string commençant par `?c` n'est pas passée.

## :rainbow: Remarques
On pourra ajouter cette query string dynamiquement côté app.pix.fr.

`?c` validé avec Manux.

## :100: Pour tester
1. Accéder à la RA
2. Vérifier que les boutons d'accès à la page d'inscription et de connexion sont bien présents
Ex: https://pix-tutos-review-pr16.osc-fr1.scalingo.io/les-tutos
3. Ajouter la query string `?connecte` sur n'importe quelle page et vérifier que ces liens ont disparu.
Ex: https://pix-tutos-review-pr16.osc-fr1.scalingo.io/la-certification?c

