### PR TITLE
[TECH] Pouvoir activer l'indexation grâce à une variable d'environnement (PIX-5142).

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,3 +1,5 @@
+import isSeoIndexingEnabled from './services/is-seo-indexing-enabled';
+
 export default {
   target: 'static',
   components: true,
@@ -15,6 +17,7 @@ export default {
         content:
           'Pix est le service public en ligne pour évaluer, développer et certifier ses compétences numériques tout au long de la vie.',
       },
+      isSeoIndexingEnabled() ? {} : { name: 'robots', content: 'noindex' },
     ],
   },
   modules: ['@nuxt/content', '@nuxtjs/style-resources'],

--- a/services/is-seo-indexing-enabled.js
+++ b/services/is-seo-indexing-enabled.js
@@ -1,0 +1,3 @@
+export default function isSeoIndexingEnabled() {
+  return process.env.SEO_ENABLE_INDEXING === 'true'
+}


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, l'indexation est activé sur tous les environnements. Cependant nous souhaitons avoir uniquement la production d'indexé et uniquement quand on le souhaitera. 

## :robot: Solution
Ajouter l'ajout d'une balise meta robot noindex conditionné par une variable d'environnement.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._

