### PR TITLE
[BUGFIX] La hauteur de la vidéo d'un tutoriel ne doit pas être trop grande

### DIFF
--- a/components/PixTutorial.vue
+++ b/components/PixTutorial.vue
@@ -96,6 +96,7 @@ export default {
 
 .tuto__video {
   width: 100%;
+  max-height: 95vmin;
   aspect-ratio: 16/9;
   margin: 2rem 0;
 }

--- a/components/PixTutorial.vue
+++ b/components/PixTutorial.vue
@@ -8,12 +8,20 @@
       class="tuto__actions"
     >
       <li v-if="videoDlHref" class="tuto-actions__item">
-        <PixButtonLink :href="videoDlHref" target="_blank" rel="noopener noreferrer">
+        <PixButtonLink
+          :href="videoDlHref"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
           Télécharger la video
         </PixButtonLink>
       </li>
       <li v-if="fichePdfHref" class="tuto-actions__item">
-        <PixButtonLink :href="fichePdfHref" target="_blank" rel="noopener noreferrer">
+        <PixButtonLink
+          :href="fichePdfHref"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
           Télécharger la fiche
         </PixButtonLink>
       </li>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -57,7 +57,7 @@
 
 .main-container {
   padding: 4rem 1rem;
-  max-width: 1280px;
+  max-width: 980px;
   margin: 0 auto;
 }
 </style>

--- a/layouts/error.vue
+++ b/layouts/error.vue
@@ -2,9 +2,9 @@
   <div class="error">
     <a href="https://pix.fr/">
       <img
-          class="error__logo"
-          src="../assets/images/pix-logo.svg"
-          alt="Lien pour revenir à l'accueil"
+        class="error__logo"
+        src="../assets/images/pix-logo.svg"
+        alt="Lien pour revenir à l'accueil"
       />
     </a>
     <p class="error__message">{{ error.message }}</p>
@@ -23,9 +23,9 @@ export default {
   head() {
     return {
       title: 'Erreur | Pix-tutos',
-    }
+    };
   },
-}
+};
 </script>
 
 <style lang="scss">

--- a/layouts/simple.vue
+++ b/layouts/simple.vue
@@ -7,5 +7,5 @@
 <script>
 export default {
   name: 'Simple',
-}
+};
 </script>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -4,7 +4,7 @@ export default {
   target: 'static',
   components: true,
   generate: {
-    fallback: '404.html'
+    fallback: '404.html',
   },
   head: {
     title: 'Pix+Edu tutos',

--- a/pages/_slug.vue
+++ b/pages/_slug.vue
@@ -32,10 +32,10 @@ export default {
         {
           hid: 'description',
           name: 'description',
-          content: this.page.description
-        }
-      ]
-    }
-  }
+          content: this.page.description,
+        },
+      ],
+    };
+  },
 };
 </script>

--- a/services/is-seo-indexing-enabled.js
+++ b/services/is-seo-indexing-enabled.js
@@ -1,3 +1,3 @@
 export default function isSeoIndexingEnabled() {
-  return process.env.SEO_ENABLE_INDEXING === 'true'
+  return process.env.SEO_ENABLE_INDEXING === 'true';
 }


### PR DESCRIPTION
## :unicorn: Problème
La vidéo était parfois plus grande que le viewport.

## :robot: Solution
Réduire la largeur du container et prévoir le cas où le viewport est vraiment petit pour avoir une taille de vidéo relative.

## :rainbow: Remarques
On s'est aussi servi de la PR pour lint le code

## :100: Pour tester
Ouvrir une page tuto et réduire la hauteur et/ou la largeur de l'écran et vérifier que la vidéo ne déborde pas.

