### PR TITLE
[TECH] Ajout du linter dans le CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,27 @@
+---
+version: 2.0
+
+jobs:
+  test:
+    docker:
+      - image: cimg/node:16.14.0
+    steps:
+      - checkout
+      - run: cat package*.json > cachekey
+      - restore_cache:
+          keys:
+            - pix-tutos-npm-{{ checksum "cachekey" }}
+      - run: npm ci
+      - save_cache:
+          key: pix-tutos-npm-{{ checksum "cachekey" }}
+          paths:
+            - ~/.npm
+      - run:
+          name: Lint
+          command: |
+            npm run lint
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - test


### PR DESCRIPTION
## :unicorn: Problème
On ne lançait pas le linter dans le CI.

## :robot: Solution
L'ajouter

## :rainbow: Remarques
On s'est basé sur la config de pix-site.

## :100: Pour tester
Pusher un commit mal formaté de test et voir que la CI ne passe pas.
