### PR TITLE
[FEATURE] Ajouter Matomo Tag Manager comme suivie d'audience (PIX-5328).

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -1,0 +1,6 @@
+export const config = {
+  matomo: {
+    containerUrl: process.env.MATOMO_CONTAINER,
+    debug: process.env.MATOMO_DEBUG || false,
+  },
+};

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,6 +1,7 @@
+import { config } from './config/environment';
 import isSeoIndexingEnabled from './services/is-seo-indexing-enabled';
 
-export default {
+const nuxtConfig = {
   target: 'static',
   components: true,
   generate: {
@@ -31,3 +32,21 @@ export default {
     ],
   },
 };
+
+if (config.matomo.containerUrl) {
+  nuxtConfig.head.script.push(
+    {
+      type: 'text/javascript',
+      src: config.matomo.containerUrl,
+      async: true,
+      defer: true,
+    },
+    {
+      type: 'text/javascript',
+      src: '/scripts/start-matomo-event.js',
+      'data-matomo-debug-mode': config.matomo.debug,
+    }
+  );
+}
+
+export default nuxtConfig;

--- a/static/scripts/start-matomo-event.js
+++ b/static/scripts/start-matomo-event.js
@@ -1,0 +1,8 @@
+// eslint-disable-next-line no-var,no-use-before-define
+var _mtm = _mtm || [];
+
+if (document.querySelector('script[data-matomo-debug-mode="true"]')) {
+  _mtm.push(['enableDebugMode']);
+}
+
+_mtm.push({ 'mtm.startTime': new Date().getTime(), event: 'mtm.Start' });


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, nous n'avons pas l'audience de ce site

## :robot: Solution
Ajouter Matomo Tag Manager comme sur les autres sites

## :rainbow: Remarques
La variable a été ajouté sur l'environnement de production

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._

