### PR TITLE
[TECH] Ajoute un saut de ligne dans le commentaire Jira (PIX-5243)

### DIFF
--- a/scripts/jira/comment-with-review-app-url.js
+++ b/scripts/jira/comment-with-review-app-url.js
@@ -60,7 +60,7 @@ async function main() {
   } else {
     const text =
       "Je viens de déployer la Review App. Elle sera consultable sur l'URL suivante :\n" +
-      `- Tutos : ${raTutosURL}\n` +
+      `- Tutos : ${raTutosURL}\n\n` +
       `Le lien Github de la PR : ${prGithubURL}`;
 
     console.log(


### PR DESCRIPTION
## :unicorn: Problème
Sur Jira, le commentaire généré ne fait pas de nouveau paragraphe après le lien de la RA dans le commentaire de création de PR.

<img width="562" alt="image" src="https://user-images.githubusercontent.com/5855339/176379692-fe448d6f-22d1-44e4-9b23-dc78004c5e40.png">

## :robot: Solution
Comme sur les autres applis, utiliser 2 sauts de ligne. Exemple : https://github.com/1024pix/pix/blob/9d3248e64807dffe1f0905e6d42be5232c2107c3/scripts/jira/comment-with-review-app-url.js#L60

## :rainbow: Remarques
RAS

## :100: Pour tester
Voir le résultat avec cette PR.

