### PR TITLE
[BUGFIX] Ajouter le script Matomo Tag Manager

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -23,6 +23,7 @@ const nuxtConfig = {
       },
       isSeoIndexingEnabled() ? {} : { name: 'robots', content: 'noindex' },
     ],
+    script: [],
   },
   modules: ['@nuxt/content', '@nuxtjs/style-resources'],
   styleResources: {


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, l'ajout du script de Matomo TM, ne fonctionne pas car la valeur `script` n'est pas défini dans `nuxtConfig`.

## :robot: Solution
Ajouter cette valeur avec un tableau vide

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._

