### PR TITLE
[FEATURE] Ajouter le contexte Pix+Édu dans le titre de la page d'un tuto

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -8,7 +8,7 @@ const nuxtConfig = {
     fallback: '404.html',
   },
   head: {
-    title: 'Pix+Edu tutos',
+    titleTemplate: '%s - Pix+Édu',
     htmlAttrs: {
       lang: 'fr',
     },

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -16,5 +16,10 @@ export default {
       tutos,
     };
   },
+  head() {
+    return {
+      title: 'Accueil',
+    };
+  },
 };
 </script>


### PR DESCRIPTION
## :unicorn: Problème
On ne sait pas que le tuto appartient à Pix+Édu. Remonté par Romain.

## :robot: Solution
Ajouter le contexte Pix+Édu dans le titre de la page.

## :rainbow: Remarques
Est-ce que ça sera bien utilisé pour l'indexation Google ?

## :100: Pour tester
Vérifier le title de la page.
