### PR TITLE
[FEATURE] Intégration page d'accueil Pix+Édu (PIX-5631)

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,16 @@
+{
+  "env": {
+    "test": {
+      "presets": [
+        [
+          "@babel/preset-env",
+          {
+            "targets": {
+              "node": "current"
+            }
+          }
+        ]
+      ]
+    }
+  }
+}

--- a/assets/scss/globals.scss
+++ b/assets/scss/globals.scss
@@ -4,6 +4,8 @@
 $open-sans: 'Open Sans', Arial, sans-serif;
 $roboto: 'Roboto', Arial, sans-serif;
 
+$pix-neutral-0: #ffffff;
+
 $black-90: #172b4d;
 $black-60: #505f79;
 $black-50: #5e6c84;

--- a/components/PixTutorial.vue
+++ b/components/PixTutorial.vue
@@ -1,8 +1,12 @@
 <template>
   <section class="tuto">
-    <h1 class="tuto__title">{{ title }}</h1>
-    <p class="tuto__description">{{ description }}</p>
+    <PixTypography tag="h1" class="tuto__title">{{ title }}</PixTypography>
+    <PixTypography tag="p" class="tuto__description">{{
+      description
+    }}</PixTypography>
+
     <iframe class="tuto__video" :src="videoEmbedSrc" />
+
     <ul
       v-if="videoDlHref || fichePdfHref || transcriptPdfHref"
       class="tuto__actions"
@@ -74,39 +78,26 @@ export default {
 </script>
 
 <style lang="scss">
-.tuto__title {
-  margin: 0;
-  font-weight: 300;
-  font-size: 3rem;
-  line-height: 1.25;
-  text-align: center;
-  letter-spacing: -0.04em;
-  color: $black-90;
-}
+.tuto {
+  .tuto__description {
+    margin: 1rem 0 0;
+  }
 
-.tuto__description {
-  margin: 1rem 0 0;
-  font-style: normal;
-  font-weight: 400;
-  font-size: 1.25rem;
-  line-height: 1.4;
-  text-align: center;
-  color: $black-60;
-}
+  &__video {
+    width: 100%;
+    max-height: 95vmin;
+    aspect-ratio: 16/9;
+    margin: 2rem 0;
+  }
 
-.tuto__video {
-  width: 100%;
-  max-height: 95vmin;
-  aspect-ratio: 16/9;
-  margin: 2rem 0;
-}
-
-.tuto__actions {
-  display: flex;
-  flex-wrap: wrap;
-  list-style-type: none;
-  gap: 1rem;
-  padding: 0;
-  margin: 0;
+  &__actions {
+    display: flex;
+    justify-content: center;
+    flex-wrap: wrap;
+    list-style-type: none;
+    gap: 1rem;
+    padding: 0;
+    margin: 0;
+  }
 }
 </style>

--- a/components/PixTypography.vue
+++ b/components/PixTypography.vue
@@ -1,0 +1,57 @@
+<template>
+  <component :is="tag"><slot /></component>
+</template>
+
+<script>
+export default {
+  name: 'PixTypography',
+  props: {
+    tag: {
+      type: String,
+      required: true,
+    },
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+h1 {
+  font-family: $open-sans;
+  font-weight: 300;
+  font-size: 3.75rem;
+  line-height: 4.5rem;
+  letter-spacing: -0.04em;
+  color: $black-90;
+  margin: 0;
+}
+
+h2 {
+  font-family: $open-sans;
+  font-weight: 600;
+  font-size: 1.5rem;
+  line-height: 2rem;
+  letter-spacing: -0.02em;
+  color: $black-90;
+  margin: 0;
+}
+
+h3 {
+  font-family: $open-sans;
+  font-weight: 700;
+  font-size: 1.25rem;
+  line-height: 1.75rem;
+  letter-spacing: 0em;
+  color: $black-90;
+  margin: 0;
+}
+
+p {
+  font-family: $roboto;
+  font-style: normal;
+  font-weight: 400;
+  font-size: 1.5rem;
+  line-height: 2rem;
+  color: $black-90;
+  margin: 0;
+}
+</style>

--- a/pages/edu/_slug.vue
+++ b/pages/edu/_slug.vue
@@ -1,12 +1,16 @@
 <template>
-  <PixTutorial
-    :title="page.title"
-    :description="page.description"
-    :video-embed-src="page.videoEmbedSrc"
-    :video-dl-href="page.videoDLHref"
-    :fiche-pdf-href="page.fichePdfHref"
-    :transcript-pdf-href="page.transcriptPdfHref"
-  />
+  <article>
+    <NuxtLink :to="{ name: 'edu' }"> ‹ Retour à la liste </NuxtLink>
+
+    <PixTutorial
+      :title="page.title"
+      :description="page.description"
+      :video-embed-src="page.videoEmbedSrc"
+      :video-dl-href="page.videoDLHref"
+      :fiche-pdf-href="page.fichePdfHref"
+      :transcript-pdf-href="page.transcriptPdfHref"
+    />
+  </article>
 </template>
 
 <script>
@@ -40,3 +44,20 @@ export default {
   },
 };
 </script>
+
+<style lang="scss" scoped>
+a {
+  font-family: $roboto;
+  font-style: normal;
+  font-weight: 400;
+  font-size: 1.5rem;
+  line-height: 2rem;
+  color: $black-90;
+  margin: 0;
+
+  &:hover {
+    color: $blue-hover;
+    text-decoration-color: $blue-hover;
+  }
+}
+</style>

--- a/pages/edu/index.vue
+++ b/pages/edu/index.vue
@@ -1,17 +1,41 @@
 <template>
-  <ul>
-    <li v-for="tuto in tutos" :key="tuto.slug">
-      <nuxt-link :to="{ name: 'edu-slug', params: { slug: tuto.slug } }">
-        {{ tuto.title }}
-      </nuxt-link>
-    </li>
-  </ul>
+  <div>
+    <PixTypography tag="h1" class="header__title"
+      >Tutoriels Canopé</PixTypography
+    >
+
+    <PixTypography tag="p" class="header__description">
+      Améliorez vos compétences abordées par les parcours Pix+Edu grâce aux
+      tutoriels vidéos du réseau Canopé.
+    </PixTypography>
+
+    <section>
+      <article v-for="(areaTutos, area) of tutosGroupedByArea" :key="area">
+        <PixTypography tag="h2" class="area__title">
+          <span class="area__number">{{ area }}</span>
+          <span v-if="areas[area]" class="area__name">{{ areas[area] }}</span>
+        </PixTypography>
+
+        <ul>
+          <li v-for="tuto in areaTutos" :key="tuto.slug">
+            <nuxt-link :to="{ name: 'edu-slug', params: { slug: tuto.slug } }">
+              <PixTypography tag="h3" class="tuto-block">
+                {{ tuto.title }}
+              </PixTypography>
+            </nuxt-link>
+          </li>
+        </ul>
+      </article>
+    </section>
+  </div>
 </template>
 
 <script>
+import PixTypography from '../../components/PixTypography.vue';
 import getAreas from '../../services/get-areas';
 
 export default {
+  components: { PixTypography },
   layout: 'edu',
   async asyncData({ $content }) {
     const tutos = await $content('edu').sortBy('area').fetch();
@@ -27,7 +51,6 @@ export default {
     return {
       areas: getAreas(),
       tutosGroupedByArea,
-      tutos,
     };
   },
   head() {
@@ -37,3 +60,49 @@ export default {
   },
 };
 </script>
+
+<style lang="scss" scoped>
+a {
+  text-decoration: none;
+  color: $black-90;
+}
+
+ul {
+  list-style: none;
+  padding-left: 0;
+}
+
+.header {
+  &__title {
+    margin-bottom: 8px;
+  }
+  &__description {
+    margin-bottom: 12px;
+  }
+}
+
+.area {
+  &__title {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    margin-top: 32px;
+    margin-bottom: 20px;
+  }
+  &__name {
+    font-weight: 500;
+  }
+}
+
+.tuto-block {
+  border-radius: 10px;
+  padding: 16px 24px;
+  background: $pix-neutral-0;
+  box-shadow: $box-shadow-xs;
+  margin-bottom: 8px;
+
+  &:hover {
+    color: $blue-hover;
+  }
+}
+</style>

--- a/pages/edu/index.vue
+++ b/pages/edu/index.vue
@@ -9,11 +9,24 @@
 </template>
 
 <script>
+import getAreas from '../../services/get-areas';
+
 export default {
   layout: 'edu',
   async asyncData({ $content }) {
-    const tutos = await $content('edu').fetch();
+    const tutos = await $content('edu').sortBy('area').fetch();
+
+    const tutosGroupedByArea = tutos.reduce((acc, tuto) => {
+      if (!acc[tuto.area]) {
+        acc[tuto.area] = [];
+      }
+      acc[tuto.area].push(tuto);
+      return acc;
+    }, {});
+
     return {
+      areas: getAreas(),
+      tutosGroupedByArea,
       tutos,
     };
   },

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,9 +1,13 @@
 <template>
-  <h1><nuxt-link to="edu">Tutos Pix+Édu</nuxt-link></h1>
+  <PixTypography tag="h1"
+    ><nuxt-link to="edu">Tutos Pix+Édu</nuxt-link></PixTypography
+  >
 </template>
 
 <script>
+import PixTypography from '../components/PixTypography.vue';
 export default {
+  components: { PixTypography },
   head() {
     return {
       title: 'Accueil',

--- a/services/get-areas.js
+++ b/services/get-areas.js
@@ -1,0 +1,13 @@
+export default function getAreas() {
+  return {
+    'Domaine 1':
+      'Utiliser le numérique pour agir et se former dans son environnement professionnel',
+    'Domaine 2': 'Sélectionner, créer et gérer des ressources',
+    'Domaine 3':
+      "Concevoir, scénariser, mettre en oeuvre et évaluer des situations d'enseignement-apprentissage",
+    'Domaine 4':
+      'Inclure et rendre accessible, différencier et engager les apprenants',
+    'Domaine 5':
+      'Développer, évaluer et certifier les compétences numériques des apprenants',
+  };
+}

--- a/tests/verify-edu-content.test.js
+++ b/tests/verify-edu-content.test.js
@@ -1,5 +1,6 @@
-const path = require('path');
-const fs = require('fs');
+import path from 'path';
+import fs from 'fs';
+import getAreas from '../services/get-areas';
 
 describe('Verification du contenu dans le dossier `content/edu`', function () {
   const contentPath = path.join(__dirname, '../content/edu');
@@ -27,12 +28,21 @@ describe('Verification du contenu dans le dossier `content/edu`', function () {
         }
       });
 
-      it('doit avoir un champ `area`', function () {
+      it('doit avoir un champ `area` existant', function () {
         try {
           expect(tutoFileContent.area).toBeDefined();
           expect(typeof tutoFileContent.area).toBe('string');
         } catch {
           throw new Error('Le champ "area" est obligatoire.');
+        }
+        try {
+          expect(getAreas()).toHaveProperty(tutoFileContent.area);
+        } catch {
+          throw new Error(
+            `Cette valeur d'"area" n'est pas permise. Valeurs permises : ${Object.keys(
+              getAreas()
+            )}`
+          );
         }
       });
 
@@ -63,19 +73,22 @@ describe('Verification du contenu dans le dossier `content/edu`', function () {
       });
 
       it('ne doit pas contenir des champs inconnus', function () {
+        const acceptedFields = [
+          'area',
+          'title',
+          'description',
+          'videoEmbedSrc',
+          'videoDLHref',
+          'fichePdfHref',
+          'transcriptPdfHref',
+        ];
         try {
-          expect([
-            'area',
-            'title',
-            'description',
-            'videoEmbedSrc',
-            'videoDLHref',
-            'fichePdfHref',
-            'transcriptPdfHref',
-          ]).toEqual(expect.arrayContaining(Object.keys(tutoFileContent)));
+          expect(acceptedFields).toEqual(
+            expect.arrayContaining(Object.keys(tutoFileContent))
+          );
         } catch {
           throw new Error(
-            `Des champs inconnus sont présents. Champs attendus : "area", "title", "description", "videoEmbedSrc", "videoDLHref", "fichePdfHref", "transcriptPdfHref".`
+            `Des champs inconnus sont présents. Champs attendus : ${acceptedFields}.`
           );
         }
       });


### PR DESCRIPTION
## :unicorn: Problème
Après l’ajout des infos de domaine (champ area), on peut concevoir une plus jolie page d'accueil de Pix+Édu.

## :robot: Solution
Intégrer la maquette des sous pages de Pix+Édu : la page d'accueil et un lien pour y retourner depuis un tuto. On se laisse quelques libertés sur le design, sur les blocs tutos l'info "vidéo" et "durée" ne sont pas nécessaires dans ce MVP.

## :rainbow: Remarques
On a essayé de faire attention à la typo en reprenant ce qu'on trouve dans les design tokens typography mais on est pas très convaincus du résultat. On a créé un composant `PixTypography` pour mettre en commun les styles et la sémantique des pages.

On vérifie maintenant dans la CI que l'`area` sélectionnée possède bien une traduction de notre côté.

## :100: Pour tester
Checker la RA.
