### PR TITLE
[FEATURE] Customiser le lecteur vidéo (PIX-5659).

### DIFF
--- a/components/PixTutorial.vue
+++ b/components/PixTutorial.vue
@@ -5,7 +5,7 @@
       description
     }}</PixTypography>
 
-    <iframe class="tuto__video" :src="videoEmbedSrc" />
+    <iframe class="tuto__video" :src="videoEmbedSrc" allowfullscreen />
 
     <ul
       v-if="videoDlHref || fichePdfHref || transcriptPdfHref"

--- a/pages/edu/_slug.vue
+++ b/pages/edu/_slug.vue
@@ -5,7 +5,7 @@
     <PixTutorial
       :title="page.title"
       :description="page.description"
-      :video-embed-src="page.videoEmbedSrc"
+      :video-embed-src="videoEmbedSrc"
       :video-dl-href="page.videoDLHref"
       :fiche-pdf-href="page.fichePdfHref"
       :transcript-pdf-href="page.transcriptPdfHref"
@@ -14,6 +14,8 @@
 </template>
 
 <script>
+import customizeEmbedVideo from '~/services/customizing-embed-video';
+
 export default {
   layout: 'edu',
   async asyncData({ $content, params, error }) {
@@ -41,6 +43,11 @@ export default {
         },
       ],
     };
+  },
+  computed: {
+    videoEmbedSrc() {
+      return customizeEmbedVideo(this.page.videoEmbedSrc);
+    },
   },
 };
 </script>

--- a/services/customizing-embed-video.js
+++ b/services/customizing-embed-video.js
@@ -1,0 +1,8 @@
+export default function customizeEmbedVideo(href) {
+  const url = new URL(href);
+  url.searchParams.append('title', 0);
+  url.searchParams.append('warningTitle', 0);
+  url.searchParams.append('peertubeLink', 0);
+  url.searchParams.append('p2p', 0);
+  return url.href;
+}

--- a/tests/services/customizing-embed-video.test.js
+++ b/tests/services/customizing-embed-video.test.js
@@ -1,0 +1,28 @@
+import customizeEmbedVideo from '../../services/customizing-embed-video';
+
+describe('Unit | Services | Customizing Embed Video', function () {
+  describe('#customizeEmbedVideo', function () {
+    const urls = [
+      {
+        url: 'https://ma-super-video.example.net/videoId',
+        expectedUrl:
+          'https://ma-super-video.example.net/videoId?title=0&warningTitle=0&peertubeLink=0&p2p=0',
+      },
+      {
+        url: 'https://ma-super-video.example.net/videoId?toto=2',
+        expectedUrl:
+          'https://ma-super-video.example.net/videoId?toto=2&title=0&warningTitle=0&peertubeLink=0&p2p=0',
+      },
+    ];
+
+    urls.forEach(({ url, expectedUrl }) => {
+      it(`should add query params to equal ${expectedUrl}`, function () {
+        // when
+        const result = customizeEmbedVideo(url);
+
+        // then
+        expect(result).toEqual(expectedUrl);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Le lecteur vidéo affiche des informations qu'on ne souhaite pas comme : 
- le bouton "PeerTube"
- le titre de la vidéo
- le warning comme quoi l'IP est stockée

## :robot: Solution
Ajouter des queryParams à l'url pour customiser l'url.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Aller sur un tuto et constater qu'il n'y plus les éléments
