### PR TITLE
[FEATURE] Ajustements lien retour à la liste + libellé (PIX-5676)

### DIFF
--- a/pages/edu/_slug.vue
+++ b/pages/edu/_slug.vue
@@ -1,7 +1,5 @@
 <template>
   <article>
-    <NuxtLink :to="{ name: 'edu' }"> ‹ Retour à la liste </NuxtLink>
-
     <PixTutorial
       :title="page.title"
       :description="page.description"
@@ -51,20 +49,3 @@ export default {
   },
 };
 </script>
-
-<style lang="scss" scoped>
-a {
-  font-family: $roboto;
-  font-style: normal;
-  font-weight: 400;
-  font-size: 1.5rem;
-  line-height: 2rem;
-  color: $black-90;
-  margin: 0;
-
-  &:hover {
-    color: $blue-hover;
-    text-decoration-color: $blue-hover;
-  }
-}
-</style>

--- a/pages/edu/index.vue
+++ b/pages/edu/index.vue
@@ -5,8 +5,8 @@
     >
 
     <PixTypography tag="p" class="header__description">
-      Améliorez vos connaissances sur les thèmes abordés dans Pix+Édu à l'aide
-      de tutoriels vidéo produits par le Réseau Canopé, en partenariat avec Pix.
+      Améliorez vos compétences sur les thèmes abordés dans Pix+Édu à l'aide de
+      tutoriels vidéo produits par le Réseau Canopé, en partenariat avec Pix.
     </PixTypography>
 
     <section>


### PR DESCRIPTION
## :unicorn: Problème
Le lien de retour à la liste des tutos Pix+Édu est incohérent dans le contexte de présentation des tutos.

## :robot: Solution
Supprimer le lien.

## :rainbow: Remarques
Aussi correction d'un libellé.

## :100: Pour tester
Vérifier sur la RA que le lien n'apparaît plus et que le libellé est à jour.

