### PR TITLE
[FEATURE] Amélioration design typographies

### DIFF
--- a/assets/scss/globals.scss
+++ b/assets/scss/globals.scss
@@ -4,6 +4,7 @@
 $open-sans: 'Open Sans', Arial, sans-serif;
 $roboto: 'Roboto', Arial, sans-serif;
 
+$pix-neutral-50: #5e6c84;
 $pix-neutral-0: #ffffff;
 
 $black-90: #172b4d;

--- a/components/PixTutorial.vue
+++ b/components/PixTutorial.vue
@@ -1,7 +1,9 @@
 <template>
   <section class="tuto">
-    <PixTypography tag="h1" class="tuto__title">{{ title }}</PixTypography>
-    <PixTypography tag="p" class="tuto__description">{{
+    <PixTypography tag="h1" scale="title-medium" class="tuto__title">{{
+      title
+    }}</PixTypography>
+    <PixTypography tag="p" scale="body-large" class="tuto__description">{{
       description
     }}</PixTypography>
 

--- a/components/PixTypography.vue
+++ b/components/PixTypography.vue
@@ -1,5 +1,5 @@
 <template>
-  <component :is="tag"><slot /></component>
+  <component :is="tag" :class="`pix-${scale}`"><slot /></component>
 </template>
 
 <script>
@@ -7,6 +7,10 @@ export default {
   name: 'PixTypography',
   props: {
     tag: {
+      type: String,
+      required: true,
+    },
+    scale: {
       type: String,
       required: true,
     },

--- a/components/PixTypography.vue
+++ b/components/PixTypography.vue
@@ -19,43 +19,119 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-h1 {
+* {
+  color: $black-90;
+  margin: 0;
+}
+
+.pix-title-large {
   font-family: $open-sans;
-  font-weight: 300;
-  font-size: 3.75rem;
-  line-height: 4.5rem;
+  font-size: 2rem;
+  line-height: 2.5625rem;
   letter-spacing: -0.04em;
-  color: $black-90;
-  margin: 0;
+  font-weight: 500;
 }
 
-h2 {
+/* Tablet */
+@media (min-width: 768px) {
+  .pix-title-large {
+    font-size: 2.5rem;
+    line-height: 3.125rem;
+    letter-spacing: -0.04em;
+  }
+}
+
+/* Desktop */
+@media (min-width: 980px) {
+  .pix-title-large {
+    font-size: 3rem;
+    line-height: 3.76rem;
+    letter-spacing: -0.04em;
+  }
+}
+
+.pix-title-medium {
   font-family: $open-sans;
-  font-weight: 600;
-  font-size: 1.5rem;
-  line-height: 2rem;
+  font-size: 1.625rem;
+  line-height: 2.0625rem;
   letter-spacing: -0.02em;
-  color: $black-90;
-  margin: 0;
+  font-weight: 500;
 }
 
-h3 {
+@media (min-width: 768px) {
+  .pix-title-medium {
+    font-size: 2rem;
+    line-height: 2.5625rem;
+    letter-spacing: -0.04em;
+  }
+}
+
+@media (min-width: 980px) {
+  .pix-title-medium {
+    font-size: 2.25rem;
+    line-height: 2.875rem;
+    letter-spacing: -0.04em;
+  }
+}
+
+.pix-title-small {
   font-family: $open-sans;
-  font-weight: 700;
-  font-size: 1.25rem;
+  font-size: 1.375rem;
   line-height: 1.75rem;
-  letter-spacing: 0em;
-  color: $black-90;
-  margin: 0;
+  letter-spacing: -0.02em;
+  font-weight: 500;
 }
 
-p {
+@media (min-width: 768px) {
+  .pix-title-small {
+    font-size: 1.5rem;
+    line-height: 2rem;
+    letter-spacing: -0.02em;
+  }
+}
+
+@media (min-width: 980px) {
+  .pix-title-small {
+    font-size: 1.75rem;
+    line-height: 2.25rem;
+    letter-spacing: -0.02em;
+  }
+}
+
+.pix-title-extra-small {
+  font-family: $open-sans;
+  font-size: 1.25rem;
+  line-height: 1.5rem;
+  letter-spacing: -0.02em;
+  font-weight: 500;
+}
+
+.pix-body-large {
   font-family: $roboto;
-  font-style: normal;
+  font-size: 1.125rem;
+  line-height: 1.6875rem;
   font-weight: 400;
-  font-size: 1.5rem;
-  line-height: 2rem;
-  color: $black-90;
-  margin: 0;
+}
+
+.pix-body-medium {
+  font-family: $roboto;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  font-weight: 400;
+}
+
+.pix-body-small {
+  font-family: $roboto;
+  font-size: 0.875rem;
+  line-height: 1.3125rem;
+  font-weight: 400;
+}
+
+.pix-body-extra-small {
+  font-family: $roboto;
+  font-size: 0.75rem;
+  line-height: 0.875rem;
+  letter-spacing: 0.02rem;
+  font-weight: 400;
 }
 </style>

--- a/pages/edu/index.vue
+++ b/pages/edu/index.vue
@@ -1,25 +1,33 @@
 <template>
   <div>
-    <PixTypography tag="h1" class="header__title"
+    <PixTypography tag="h1" scale="title-large" class="header__title"
       >Tutoriels Réseau Canopé-Pix</PixTypography
     >
 
-    <PixTypography tag="p" class="header__description">
+    <PixTypography tag="p" scale="body-large" class="header__description">
       Améliorez vos compétences sur les thèmes abordés dans Pix+Édu à l'aide de
       tutoriels vidéo produits par le Réseau Canopé, en partenariat avec Pix.
     </PixTypography>
 
     <section>
       <article v-for="(areaTutos, area) of tutosGroupedByArea" :key="area">
-        <PixTypography tag="h2" class="area__title">
+        <PixTypography tag="h2" scale="title-small" class="area__title">
           <span class="area__number">{{ area }}</span>
           <span v-if="areas[area]" class="area__name">{{ areas[area] }}</span>
         </PixTypography>
 
-        <ul>
-          <li v-for="tuto in areaTutos" :key="tuto.slug">
+        <ul class="tutorial-list">
+          <li
+            v-for="tuto in areaTutos"
+            :key="tuto.slug"
+            class="tutorial-list__item"
+          >
             <nuxt-link :to="{ name: 'edu-slug', params: { slug: tuto.slug } }">
-              <PixTypography tag="h3" class="tuto-block">
+              <PixTypography
+                tag="h3"
+                scale="title-extra-small"
+                class="tuto-block"
+              >
                 {{ tuto.title }}
               </PixTypography>
             </nuxt-link>
@@ -77,7 +85,9 @@ ul {
     margin-bottom: 8px;
   }
   &__description {
-    margin-bottom: 12px;
+    margin-bottom: 56px;
+    color: $pix-neutral-50;
+    font-weight: 500;
   }
 }
 
@@ -89,8 +99,16 @@ ul {
     margin-top: 32px;
     margin-bottom: 20px;
   }
-  &__name {
-    font-weight: 500;
+  &__number {
+    color: $pix-neutral-50;
+  }
+}
+
+.tutorial-list {
+  margin-bottom: 40px;
+
+  &__item:not(:last-child) {
+    margin-bottom: 12px;
   }
 }
 
@@ -99,7 +117,6 @@ ul {
   padding: 16px 24px;
   background: $pix-neutral-0;
   box-shadow: $box-shadow-xs;
-  margin-bottom: 8px;
 
   &:hover {
     color: $blue-hover;

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <PixTypography tag="h1"
+  <PixTypography tag="h1" scale="title-large"
     ><nuxt-link to="edu">Tutos Pix+Édu</nuxt-link></PixTypography
   >
 </template>


### PR DESCRIPTION
## :unicorn: Problème
Les typographies que nous utilisons lient sémantique (la balise utilisée : h1, h2, h3, p...) et design. Cela limite la liberté d'avoir des titres sémantiquement valides avec un design différent quand on le souhaite (un titre qu'on sait long par exemple).

Autre problème : nous utilisons les mêmes typographies quelque soit la résolution de l'utilisateur, certains titres deviennent trop gros en mobile.

## :robot: Proposition
En collaboration avec Quentin, améliorer la section "Typographies" de Figma pour revoir un peu les typo, trouver un nommage pertinent et l'appliquer sur Pix Tutos.

On a renommé les scales pour éviter de confondre valeur sémantique et design de l'élément. On a aussi précisé les valeurs en px + rem des différents éléments qu'on a besoin de setter.

![image](https://user-images.githubusercontent.com/5855339/203598080-18f42c55-48be-438e-9ba5-6b2769a4d758.png)

Les modifs sont visibles en détail ici :
https://www.figma.com/file/y6p1FS5HKhJkMLrJN4i90P/Pix-App?node-id=2%3A7

## :rainbow: Remarques
On a aussi joué sur les couleurs pour mettre en retrait certaines infos (contraste ok normalement).

## :100: Pour tester
Vérifier que les pages s'affichent toujours bien.
