### PR TITLE
[FEATURE] Permettre l'ajout de la retranscription écrite des vidéos des tutos (PIX-7395)

### DIFF
--- a/assets/scss/globals.scss
+++ b/assets/scss/globals.scss
@@ -4,7 +4,10 @@
 $open-sans: 'Open Sans', Arial, sans-serif;
 $roboto: 'Roboto', Arial, sans-serif;
 
+$pix-neutral-90: #172b4d;
+$pix-neutral-70: #344563;
 $pix-neutral-50: #5e6c84;
+$pix-neutral-22: #c1c7d0;
 $pix-neutral-20: #dfe1e6;
 $pix-neutral-10: #f4f5f7;
 $pix-neutral-0: #ffffff;

--- a/components/PixTutorial.vue
+++ b/components/PixTutorial.vue
@@ -89,6 +89,7 @@ export default {
 .tuto {
   .tuto__description {
     margin: 1rem 0 0;
+    color: $pix-neutral-50;
   }
 
   &__video {
@@ -100,12 +101,26 @@ export default {
 
   &__actions {
     display: flex;
-    justify-content: center;
     flex-wrap: wrap;
     list-style-type: none;
     gap: 1rem;
     padding: 0;
     margin: 0;
+  }
+}
+
+.nuxt-content {
+  margin-top: 32px;
+  color: $pix-neutral-70;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  border-top: 1px solid $pix-neutral-22;
+
+  h2 {
+    margin: 32px 0 8px;
+    color: $pix-neutral-90;
+    font-size: 1.25rem;
+    font-weight: 500;
   }
 }
 </style>

--- a/components/PixTutorial.vue
+++ b/components/PixTutorial.vue
@@ -42,6 +42,8 @@
         </PixButtonLink>
       </li>
     </ul>
+
+    <nuxt-content :document="page" />
   </section>
 </template>
 
@@ -51,6 +53,10 @@ export default {
   name: 'PixTutorial',
   components: { PixButtonLink },
   props: {
+    page: {
+      type: Object,
+      required: true,
+    },
     title: {
       type: String,
       required: true,

--- a/content/edu/agir-face-au-cyberharcelement.json
+++ b/content/edu/agir-face-au-cyberharcelement.json
@@ -1,9 +1,0 @@
-{
-  "area" : "Domaine 1",
-  "title": "Agir face au cyberharcèlement",
-  "description": "Dans cette vidéo, vous trouverez des conseils et des pistes pour agir en tant que professionnel de l'éducation lorsque vous êtes témoin de situations de cyberharcèlement entre élèves.",
-  "videoEmbedSrc": "https://tube.reseau-canope.fr/videos/embed/17831907-e7cb-439a-a5c8-2e0453c878e3",
-  "videoDLHref": "https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/17831907-e7cb-439a-a5c8-2e0453c878e3-1080-fragmented.mp4",
-  "fichePdfHref": "",
-  "transcriptPdfHref": ""
-}

--- a/content/edu/agir-face-au-cyberharcelement.md
+++ b/content/edu/agir-face-au-cyberharcelement.md
@@ -1,0 +1,105 @@
+---
+area: Domaine 1
+title: Agir face au cyberharcèlement
+description: Dans cette vidéo, vous trouverez des conseils et des pistes pour agir en tant que professionnel de l'éducation lorsque vous êtes témoin de situations de cyberharcèlement entre élèves.
+videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/17831907-e7cb-439a-a5c8-2e0453c878e3
+videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/17831907-e7cb-439a-a5c8-2e0453c878e3-1080-fragmented.mp4
+---
+
+## Script
+
+Derrière son écran, on surfe d'un site à l’autre, on partage des photos avec ses amis, on
+échange sur des réseaux sociaux... Si le web est un formidable espace de communication,
+celle-ci n’est pas toujours bienveillante malheureusement.
+
+- Qu’appelle-t-on cyberharcèlement?
+- Quelles formes prend-il?
+- Qui sont les cyberharceleurs et que risquent-ils?
+- Comment réagir si l’on est victime ou témoin d’un cyberharcèlement?
+
+C’est ce que nous allons voir dans cette vidéo.
+
+Le cyberharcèlement est un acte agressif, intentionnel, perpétré en ligne par une personne
+ou un groupe de personnes de manière répétée. Cet acte va à l’encontre d’une victime qui
+peut difficilement se défendre seule.
+
+Le cyberharcèlement prend différentes formes et entraîne des conséquences dramatiques
+pour les victimes.
+
+À partir du moment où une personne ou un groupe de personne utilisent les outils
+numériques en ligne pour proférer insultes, intimidations, moqueries, rumeurs ou menaces,
+à l’encontre d’un individu, cette personne ou ce groupe de personne est auteur de
+cyberviolence. Dès que ces actes intentionnels deviennent répétés, on parle alors de
+cyberharcèlement.
+
+Ces propos inappropriés peuvent être diffusés par des voies privées (messagerie, compte
+privé) ou par des posts publics _via_ les réseaux sociaux, les jeux en ligne, les tchats, les
+forums, etc., pour être diffusés au plus grand nombre.
+
+- Le piratage de comptes et l’usurpation d’identité digitale constituent l’une des formes de cyberharcèlement. Les faux comptes nuisent à la personne à partir du moment où des publications sont régulièrement envoyées à partir de ce compte.
+- Lorsque plusieurs personnes s’acharnent sur une autre, on parle de cyberharcèlement en meute ou encore de _Happy slapping_ lorsqu’un individu est filmé en train d’être lynché et la vidéo postée sans son consentement.
+- La publication d’informations ou de révélations intimes, d’une photo ou d’une vidéo d’un individu dans une mauvaise posture sans son consentement est appelée _outing_.
+
+Le _sexting_ , envoi d’éléments intimes par sms ou tchat, peut être utilisé comme une arme de
+chantage sexuel, il s’agit alors de _sextorsion_ , ou être diffusé après une rupture : on parle
+alors de _revenge porn_.
+
+Les victimes de ces types de cyberharcèlement sont majoritairement des femmes : on parle
+de cybersexisme. Plus particulièrement, les comptes « fisha » diffusent des photos de jeunes
+femmes dénudées et donnent également des informations sur elles dans le but de les
+humilier et d’accroître le phénomène de harcèlement.
+
+Le cyberharceleur est un individu qui commet un acte agressif répété en ligne contre une
+victime qu’il attaque délibérément.
+
+Les cyberharceleurs, qu’ils soient adultes ou mineurs, anonymes ou non, ne sont pas
+toujours conscients de la portée de leurs actes. Les attaques sont parfois banalisées par une
+culture discriminant l’apparence, le genre, la norme sociale ou l’orientation sexuelle. Tout
+cela est rendu encore plus anodin par le caractère instantané et parfois éphémère des
+réseaux sociaux.
+
+Toute personne cautionnant ces actes en commentant, en likant, en partageant une
+publication, un message ou une photo, est considérée comme complice de l’auteur.
+
+Toute action visant à répéter et à accentuer le harcèlement en ligne est préjudiciable. Le
+simple fait de partager une photo engage sa responsabilité devant la loi.
+
+En France, les auteurs de cyberharcèlement encourent des peines de prison et amendes.
+Une injure ou une diffamation publique peut être punie d’une amende de 12 000 € et
+l’usurpation d’identité peut être punie d’un an d’emprisonnement et de 15 000 € d’amende.
+Récemment adoptée, la loi Balanant prévoit la création d’un délit spécifique de harcèlement
+scolaire.
+
+Le harcèlement en ligne peut avoir des conséquences dramatiques pour les victimes : baisse
+de l’estime de soi, troubles psychologiques et physiologiques, allant parfois jusqu’au suicide.
+Pour reconnaître les victimes, des signaux peuvent alerter : isolement, boulimie, insomnies,
+troubles anxiodépressifs ou phobie scolaire pour les plus jeunes.
+
+Lorsqu’on est victime, il est conseillé de ne pas répondre à ses agresseurs mais de se
+protéger en verrouillant l’ensemble de ses comptes sociaux ou en réglant ses options de
+confidentialité.
+
+Il faut collecter des preuves en faisant des captures d’écran des messages.
+
+En cas de cyberviolences graves et incessantes, il faut signaler le problème aux modérateurs
+du réseau social si l’agression a lieu sur un site public et porter plainte.
+
+Les numéros 3020 et 3018 permettent d’accompagner les victimes de manière anonyme et
+la plateforme Pharos, mise en place en 2009, permet de signaler tous comportements
+illicites repérés en ligne.
+
+Enfin, si nous avons connaissance d’une personne harcelée en ligne, n’oublions pas qu’un
+signalement peut l’aider.
+
+
+Être à l’écoute et aller vers les personnes victimes de cyberharcèlement est une
+responsabilité qui incombe à chacun dans l'équipe éducative.
+
+## Crédits
+
+- **Scénario** : Kimi Do, Leinna Berradia
+- **Direction de publication** : Marie-Caroline Missir
+- **Production** : Réseau Canopé
+- **Partenariat** : Pix
+
+Ressource produite avec le soutien du ministère de l’Éducation nationale et de la Jeunesse

--- a/content/edu/appliquer-l-exception-pedagogique-et-les-exceptions-aux-droits-d-auteur.json
+++ b/content/edu/appliquer-l-exception-pedagogique-et-les-exceptions-aux-droits-d-auteur.json
@@ -1,9 +1,0 @@
-{
-  "area" : "Domaine 2",
-  "title": "Appliquer l'exception pédagogique et les exceptions aux droits d'auteur",
-  "description": "Dans cette vidéo, vous verrez en détail ce que permet l'exception pédagogique pour respecter la propriété intellectuelle de chacun. Quelles ressources peuvent être utilisées ? Sous quelles conditions ? Toutes les réponses dans la vidéo !",
-  "videoEmbedSrc": "https://tube.reseau-canope.fr/videos/embed/4512d4a2-2f3f-42e0-8958-8e6ffbb6561e",
-  "videoDLHref": "https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/4512d4a2-2f3f-42e0-8958-8e6ffbb6561e-1080-fragmented.mp4",
-  "fichePdfHref": "",
-  "transcriptPdfHref": ""
-}

--- a/content/edu/appliquer-l-exception-pedagogique-et-les-exceptions-aux-droits-d-auteur.md
+++ b/content/edu/appliquer-l-exception-pedagogique-et-les-exceptions-aux-droits-d-auteur.md
@@ -1,0 +1,7 @@
+---
+area: Domaine 2
+title: Appliquer l'exception pédagogique et les exceptions aux droits d'auteur
+description: Dans cette vidéo, vous verrez en détail ce que permet l'exception pédagogique pour respecter la propriété intellectuelle de chacun. Quelles ressources peuvent être utilisées ? Sous quelles conditions ? Toutes les réponses dans la vidéo !
+videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/4512d4a2-2f3f-42e0-8958-8e6ffbb6561e
+videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/4512d4a2-2f3f-42e0-8958-8e6ffbb6561e-1080-fragmented.mp4
+---

--- a/content/edu/cadre-et-acteurs-du-rgpd-en-milieu-scolaire.json
+++ b/content/edu/cadre-et-acteurs-du-rgpd-en-milieu-scolaire.json
@@ -1,9 +1,0 @@
-{
-  "area" : "Domaine 1",
-  "title": "Cadre et acteurs du RGPD en milieu scolaire",
-  "description": "Qu'elles soient administratives ou pédagogiques, les données à caractère personnel des élèves doivent être protégées. Le registre de traitement des données personnelles est un outil central au respect du RGPD en milieu scolaire. Prêt à en savoir plus ?",
-  "videoEmbedSrc": "https://tube.reseau-canope.fr/videos/embed/4d2fd5f5-adca-4ccb-9208-a4796f68d038",
-  "videoDLHref": "https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/4d2fd5f5-adca-4ccb-9208-a4796f68d038-1080-fragmented.mp4",
-  "fichePdfHref": "",
-  "transcriptPdfHref": ""
-}

--- a/content/edu/cadre-et-acteurs-du-rgpd-en-milieu-scolaire.md
+++ b/content/edu/cadre-et-acteurs-du-rgpd-en-milieu-scolaire.md
@@ -1,0 +1,7 @@
+---
+area: Domaine 1
+title: Cadre et acteurs du RGPD en milieu scolaire
+description: Qu'elles soient administratives ou pédagogiques, les données à caractère personnel des élèves doivent être protégées. Le registre de traitement des données personnelles est un outil central au respect du RGPD en milieu scolaire. Prêt à en savoir plus ?
+videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/4d2fd5f5-adca-4ccb-9208-a4796f68d038
+videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/4d2fd5f5-adca-4ccb-9208-a4796f68d038-1080-fragmented.mp4
+---

--- a/content/edu/communiquer-efficacement-par-differents-canaux-aupres-de-ses-eleves.json
+++ b/content/edu/communiquer-efficacement-par-differents-canaux-aupres-de-ses-eleves.json
@@ -1,9 +1,0 @@
-{
-  "area" : "Domaine 1",
-  "title": "Communiquer efficacement par différents canaux auprès de ses élèves",
-  "description": "Les canaux numériques pour communiquer avec ses élèves sont très nombreux. Quel canal choisir ? C'est ce que nous allons voir dans cette vidéo.",
-  "videoEmbedSrc": "https://tube.reseau-canope.fr/videos/embed/31ea90d9-6d86-49b1-b6e1-4cc008000dbe",
-  "videoDLHref": "https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/31ea90d9-6d86-49b1-b6e1-4cc008000dbe-1080-fragmented.mp4",
-  "fichePdfHref": "",
-  "transcriptPdfHref": ""
-}

--- a/content/edu/communiquer-efficacement-par-differents-canaux-aupres-de-ses-eleves.md
+++ b/content/edu/communiquer-efficacement-par-differents-canaux-aupres-de-ses-eleves.md
@@ -1,0 +1,86 @@
+---
+area : Domaine 1
+title: Communiquer efficacement par différents canaux auprès de ses élèves
+description: Les canaux numériques pour communiquer avec ses élèves sont très nombreux. Quel canal choisir ? C'est ce que nous allons voir dans cette vidéo.
+videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/31ea90d9-6d86-49b1-b6e1-4cc008000dbe
+videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/31ea90d9-6d86-49b1-b6e1-4cc008000dbe-1080-fragmented.mp4
+---
+
+## Script
+
+Mail académique, messagerie ENT, cahier de textes en ligne, réseaux sociaux, blog, forum...
+on peut se sentir un peu perdu devant la multiplication des canaux de communication! Pour
+communiquer avec ses élèves, un enseignant dispose de plusieurs canaux. Selon les
+objectifs, comment choisir le canal le plus adapté pour communiquer avec ses élèves?
+Quelles sont les règles de communication à respecter? C’est ce que nous allons voir dans
+cette vidéo.
+
+Beaucoup d’établissements scolaires sont équipés d’un Environnement numérique de
+travail, dit ENT. L’application de messagerie ou le logiciel de vie scolaire qui y sont intégrés,
+sont particulièrement adaptés pour communiquer avec les élèves. Pourquoi?
+
+Premièrement, c’est une application destinée à un usage interne à l'établissement.
+Enseignants et élèves ont la possibilité de communiquer entre eux sans avoir à créer un
+compte. De plus, la messagerie de l’ENT permet d’accéder rapidement aux adresses
+enregistrées dans l’annuaire en saisissant les premières lettres du destinataire. Comme les
+groupes classes sont déjà constitués, il est très facile de contacter une classe pour s’adresser
+à tous les élèves. Enfin, cette messagerie est sécurisée. Sauf exception, elle ne permet pas
+d’échanger avec l’extérieur et protège contre les tentatives de hacking, spams et virus.
+
+Depuis quelques années, le cahier de textes traditionnel a été remplacé par le cahier de
+texte numérique. Selon les établissements, il peut être intégré à l’ENT comme application ou
+géré par un logiciel de vie scolaire comme Pronote ou École Directe. Le cahier de textes
+numérique permet à l’enseignant de distribuer des devoirs et de renseigner les contenus de
+la séance. À noter que, dans le second degré, c’est une obligation légale de le remplir. Ces
+informations sont visibles par les parents et les élèves sous forme de planning.
+
+
+Intéressons-nous maintenant au blog. Intégré à l’ENT, le blog permet de publier
+régulièrement auprès d’une communauté, comme la classe ou l’établissement. C’est l’outil
+idéal pour tenir un journal de la classe, préparer un voyage scolaire et en faire un reportage,
+travailler sur un projet tout au long de l’année ou encore présenter des travaux d’élèves
+dans le cadre d’un atelier. Les articles, appelés billets, peuvent être rédigés par l’enseignant
+ou par les élèves eux-mêmes. Ils peuvent contenir du texte, des photos, du son ou des
+vidéos et peuvent même être commentés.
+
+Le forum, autre application intégrée aux ENT, permet de discuter facilement entre
+enseignant et élèves, mais surtout entre les élèves eux-mêmes. C’est l'outil idéal pour suivre
+les réflexions d'un groupe lors d'un projet. Il permet à l’enseignant de modérer les messages
+des élèves si besoin. D’autres outils dits de « classe virtuelle » permettent d’organiser et
+d’animer des séances pédagogiques à distance. C’est le cas des applications de
+visioconférence de certains ENT ou encore du dispositif « Ma classe à la maison ». Ces outils
+proposent des options telles que le partage d’un tableau blanc ou la constitution de groupes
+pour mener des ateliers. La classe virtuelle constitue un support de communication, de
+collaboration ou de remédiation efficace.
+
+Les canaux de communication sont donc nombreux. Mais quelles sont les règles de
+communication à respecter? Un cadre juridique définit les aspects liés à la communication
+sur les réseaux comme :
+
+- la liberté d’expression ;
+- la protection de la propriété intellectuelle ;
+- ou encore la protection de la personne et de la vie privée.
+
+D’autre part, des règles moins formelles sont regroupées dans une charte appelée
+Nétiquette. Ce guide donne les bonnes pratiques et les bons usages d’Internet : courtoisie,
+politesse, mise en page...
+
+Concertez-vous! Entre enseignants d’un même établissement, définissez ensemble les
+canaux de communication appropriés pour échanger avec les élèves, selon les situations.
+
+Évitez les réseaux sociaux, les messageries instantanées privées ou adresses mails
+personnelles quand vous vous adressez à la communauté éducative et en particulier aux
+élèves. Ils restent des outils à usage personnel dont la sécurité ne peut être garantie.
+
+Pour conclure, retenons que les canaux mis à disposition par l’institution sont à privilégier,
+car ils sont conformes au cadre scolaire et protègent les données personnelles de leurs
+usagers. Ils offrent un large choix à l’enseignant et permettent une communication simple et
+harmonieuse avec tous les élèves.
+
+## Crédits
+
+- **Scénario** : Corentine Gasquet, Nicolas Sedel, Nicolas Braun, Sylvain Chagnard
+- **Direction de publication** : Marie-Caroline Missir
+- **Production** : Réseau Canopé
+- **Partenariat** : Pix
+Ressource produite avec le soutien du ministère de l’Éducation nationale et de la Jeunesse

--- a/content/edu/communiquer-par-voie-numerique-aupres-de-la-communaute-educative.json
+++ b/content/edu/communiquer-par-voie-numerique-aupres-de-la-communaute-educative.json
@@ -1,9 +1,0 @@
-{
-  "area" : "Domaine 1",
-  "title": "Communiquer par voie numérique auprès de la communauté éducative",
-  "description": "Élèves, parents, partenaires : quels moyens de communications privilégier en tant qu'enseignant ? Plus d'informations dans cette vidéo.",
-  "videoEmbedSrc": "https://tube.reseau-canope.fr/videos/embed/ef3f3ced-c2ee-41c0-91c7-1b7ad83f0de5",
-  "videoDLHref": "https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/ef3f3ced-c2ee-41c0-91c7-1b7ad83f0de5-1080-fragmented.mp4",
-  "fichePdfHref": "",
-  "transcriptPdfHref": ""
-}

--- a/content/edu/communiquer-par-voie-numerique-aupres-de-la-communaute-educative.md
+++ b/content/edu/communiquer-par-voie-numerique-aupres-de-la-communaute-educative.md
@@ -1,0 +1,96 @@
+---
+area: Domaine 1
+title: Communiquer par voie numérique auprès de la communauté éducative
+description: "Élèves, parents, partenaires : quels moyens de communications privilégier en tant qu'enseignant ? Plus d'informations dans cette vidéo."
+videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/ef3f3ced-c2ee-41c0-91c7-1b7ad83f0de5
+videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/ef3f3ced-c2ee-41c0-91c7-1b7ad83f0de5-1080-fragmented.mp4
+---
+
+## Script
+
+Messagerie de l’ENT, de Pronote, cahier de texte, webmail de l’académie, réseaux sociaux...
+Qu'il s'adresse à l'administration, à l'académie, à ses collègues, ses élèves ou même aux
+parents d'élèves, chaque enseignant dispose de nombreux outils pour communiquer. Face à
+tous ces canaux de communication, c'est parfois difficile de s'y retrouver...
+
+- Quel canal choisir en fonction de ses interlocuteurs?
+- Quelles sont les bonnes pratiques selon chacun d’eux?
+- Comment protéger les données personnelles de chacun?
+
+C’est ce que nous allons voir dans cette vidéo.
+
+L’outil de communication numérique le plus évident est le mail. Un enseignant a en général
+au moins deux adresses mail :
+
+- une adresse professionnelle sur le modèle prénom.nom@ac-académie.fr ;
+- une autre personnelle.
+
+Le mail professionnel apporte de la visibilité au message envoyé. En effet, il permet
+d’attester du statut et de l'académie d’origine de l’expéditeur.
+
+Il apporte de la crédibilité par rapport à une adresse personnelle qui pourrait manquer... de
+professionnalisme!
+
+Enfin, il permet à l’enseignant de séparer sa vie professionnelle de sa vie personnelle.
+
+C’est ce qu’on appelle aussi : le droit à la déconnexion, le droit de ne pas être dérangé par
+des mails professionnels en dehors de son temps de travail.
+
+L’adresse professionnelle doit être utilisée pour toutes les missions de l’enseignant :
+
+- pour préparer une sortie scolaire ;
+- contacter des entreprises accueillant des élèves en stage ;
+- joindre les collectivités territoriales ;
+- ou encore échanger avec les parents d’élèves.
+
+Cette adresse est à privilégier également lors d’échanges avec d’autres personnels de
+l’Éducation nationale.
+
+Maintenant, quelles sont les bonnes pratiques?
+
+Le choix des destinataires est important. Lorsque vous rédigez un mail, les destinataires sont
+listés dans le champ « A : ». Le champ CC (copie Carbone) permet d’ajouter des personnes
+qui ne sont pas les destinataires prioritaires : un autre collègue ou un supérieur par exemple.
+Le champ CCI (copie carbone invisible) permet d’envoyer un même message à plusieurs
+personnes sans qu’elles n’aient accès aux adresses des autres destinataires.
+
+Pour garantir la confidentialité mais aussi pour limiter la possibilité d'utiliser le « Répondre à
+tous », cette option est à privilégier. En effet, si par malheur on utilise l'option « Répondre à
+tous », un simple mail peut faire boule de neige... et se transformer en une avalanche de
+courriers indésirables! L’option « Répondre à tous » n’est à utiliser que si la réponse est
+intéressante pour l’ensemble des destinataires.
+
+Il est conseillé de définir une signature. Les services de messagerie vous permettent d’éditer
+un bloc signature pour préciser vos fonctions et votre établissement d’affectation. Choisir un
+objet approprié permet de clarifier votre message et permettra aux destinataires de mieux
+le retrouver plus tard. Limitez votre message à une seule idée principale. Sinon, n’hésitez pas
+à envoyer plusieurs messages, avec différents objets. Si votre texte est trop long, il risque de
+ne pas être lu attentivement par tous. Vous pouvez alors recourir à une pièce jointe en PDF,
+qui est accessible sur tous types d'appareils et imprimable si besoin.
+
+Voyons maintenant du côté de l’Espace numérique de travail (l’ENT). Pour communiquer
+avec les parents d’élèves, ce canal est recommandé, notamment pour des raisons de
+protection des données personnelles. Si vous n’avez pas d’ENT, il est possible d’utiliser son
+mail académique. Bien sûr, on dispose toujours du carnet de correspondance, qui peut être
+le plus approprié dans certaines circonstances!
+
+Enfin, n’oublions pas la question des données personnelles. Bien que les réseaux sociaux
+soient des outils pratiques et puissants, ils ne peuvent pas être utilisés pour une
+communication vers les familles et les élèves notamment pour des raisons de protection des
+données personnelles. Il faut donc utiliser au maximum les possibilités offertes par les ENT
+ou les logiciels de vie scolaire. Si cela ne suffit pas, il est possible d’avoir recours aux outils
+autorisés par votre responsable de traitement et inscrits au registre des traitements de votre
+structure. Pour plus d'informations, tournez-vous vers le délégué à la protection des
+données académiques, dont l’adresse mail est par exemple dpd@ac-lyon.fr.
+
+Dans la jungle des canaux de communication, vous êtes désormais prêts à trouver votre
+chemin et à choisir le bon outil selon vos interlocuteurs.
+
+
+## Crédits
+
+- **Scénario** : Nicolas Sedel, Corentine Gasquet, Matthieu Boucher
+- **Direction de publication** : Marie-Caroline Missir
+- **Production** : Réseau Canopé
+- **Partenariat** : Pix
+Ressource produite avec le soutien du ministère de l’Éducation nationale et de la Jeunesse

--- a/content/edu/comprendre-comment-differencier-grace-au-numerique.json
+++ b/content/edu/comprendre-comment-differencier-grace-au-numerique.json
@@ -1,9 +1,0 @@
-{
-  "area" : "Domaine 4",
-  "title": "Différencier ses pratiques pédagogiques grâce au numérique",
-  "description": "Décliner et adapter les situations et les supports pédagogiques pour répondre aux besoins éducatifs particuliers des élèves sont de réels enjeux pour les enseignants. Dans cette vidéo, nous verrons comment certains outils numériques peuvent aider ce travail de différenciation.",
-  "videoEmbedSrc": "https://tube.reseau-canope.fr/videos/embed/9520b54d-0a3c-43dc-8821-d559fa418cc6",
-  "videoDLHref": "https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/9520b54d-0a3c-43dc-8821-d559fa418cc6-1080-fragmented.mp4",
-  "fichePdfHref": "",
-  "transcriptPdfHref": ""
-}

--- a/content/edu/comprendre-comment-differencier-grace-au-numerique.md
+++ b/content/edu/comprendre-comment-differencier-grace-au-numerique.md
@@ -1,0 +1,7 @@
+---
+area: Domaine 4
+title: Différencier ses pratiques pédagogiques grâce au numérique
+description: Décliner et adapter les situations et les supports pédagogiques pour répondre aux besoins éducatifs particuliers des élèves sont de réels enjeux pour les enseignants. Dans cette vidéo, nous verrons comment certains outils numériques peuvent aider ce travail de différenciation.
+videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/9520b54d-0a3c-43dc-8821-d559fa418cc6
+videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/9520b54d-0a3c-43dc-8821-d559fa418cc6-1080-fragmented.mp4
+---

--- a/content/edu/comprendre-les-creative-commons-pour-une-utilisation-pedagogique.json
+++ b/content/edu/comprendre-les-creative-commons-pour-une-utilisation-pedagogique.json
@@ -1,9 +1,0 @@
-{
-  "area" : "Domaine 2",
-  "title": "Comprendre les Creative Commons pour une utilisation pédagogique",
-  "description": "Les ressources en licence Creative Commons (CC) peuvent être des ressources précieuses lors de la création d'un support pédagogique. Voici comment s'y retrouver entre les différents types de licences CC.",
-  "videoEmbedSrc": "https://tube.reseau-canope.fr/videos/embed/17d63f12-2a68-4110-8943-dba74582befd",
-  "videoDLHref": "https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/17d63f12-2a68-4110-8943-dba74582befd-1080-fragmented.mp4",
-  "fichePdfHref": "",
-  "transcriptPdfHref": ""
-}

--- a/content/edu/comprendre-les-creative-commons-pour-une-utilisation-pedagogique.md
+++ b/content/edu/comprendre-les-creative-commons-pour-une-utilisation-pedagogique.md
@@ -1,0 +1,7 @@
+---
+area: Domaine 2
+title: Comprendre les Creative Commons pour une utilisation pédagogique
+description: Les ressources en licence Creative Commons (CC) peuvent être des ressources précieuses lors de la création d'un support pédagogique. Voici comment s'y retrouver entre les différents types de licences CC.
+videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/17d63f12-2a68-4110-8943-dba74582befd
+videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/17d63f12-2a68-4110-8943-dba74582befd-1080-fragmented.mp4
+---

--- a/content/edu/configurer-son-client-de-messagerie-pour-recevoir-ses-mails-academiques.json
+++ b/content/edu/configurer-son-client-de-messagerie-pour-recevoir-ses-mails-academiques.json
@@ -1,7 +1,0 @@
-{
-  "area" : "Domaine 1",
-  "title": "Configurer son client de messagerie pour recevoir ses mails académiques",
-  "description": "Pour éviter de jongler entre différentes boîtes mails, il est possible d'utiliser un client de messagerie pour centraliser ses emails. Toutes les informations dans cette vidéo !",
-  "videoEmbedSrc": "https://tube.reseau-canope.fr/videos/embed/4009d7ec-c48a-4a13-8198-7a083af3d61f",
-  "videoDLHref": "https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/4009d7ec-c48a-4a13-8198-7a083af3d61f-1080-fragmented.mp4"
-}

--- a/content/edu/configurer-son-client-de-messagerie-pour-recevoir-ses-mails-academiques.md
+++ b/content/edu/configurer-son-client-de-messagerie-pour-recevoir-ses-mails-academiques.md
@@ -1,0 +1,85 @@
+---
+area: Domaine 1
+title: Configurer son client de messagerie pour recevoir ses mails académiques
+description: Pour éviter de jongler entre différentes boîtes mails, il est possible d'utiliser un client de messagerie pour centraliser ses emails. Toutes les informations dans cette vidéo !
+videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/4009d7ec-c48a-4a13-8198-7a083af3d61f
+videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/4009d7ec-c48a-4a13-8198-7a083af3d61f-1080-fragmented.mp4
+---
+
+## Script
+
+Chaque enseignant a généralement plusieurs adresses mail : l’adresse académique et au
+moins une adresse personnelle.
+
+Certes, il peut s'amuser à jongler avec ses différentes adresses... mais ce n'est pas toujours
+pratique. Le premier réflexe pourrait être de transférer automatiquement ses mails
+académiques vers sa messagerie personnelle. Mais est-ce vraiment la solution?
+
+Eh bien, non! En effet, les mails sont alors stockés chez le fournisseur de votre messagerie,
+et vous n’avez plus la maîtrise sur vos données personnelles. Et, par ailleurs, cela ne permet
+pas d’envoyer des messages depuis son adresse académique.
+
+Alors, comment bien configurer un client de messagerie? C’est ce que nous allons voir dans
+cette vidéo.
+
+Thunderbird, Windows Mail, Outlook ou encore Mail... Les clients de messagerie sont des
+logiciels qui permettent de regrouper différents comptes, qu’ils soient professionnels ou
+privés, et de se servir de l’un d’eux selon les circonstances. Ces solutions sont accessibles
+depuis un smartphone, une tablette ou un ordinateur.
+
+La première étape est d’ouvrir le client de messagerie et d’accéder à la rubrique Paramètres,
+généralement symbolisée par une petite roue crantée. Dans « Compte », il faut ensuite
+cliquer sur « Nouveau » ou « Ajouter un compte ».
+
+L’écran qui s’ouvre peut sembler effrayant! Pas d'inquiétude, voici, pas à pas, les réglages à
+effectuer.
+
+Dans les premiers champs, il faut simplement saisir son nom tel qu’il doit d’afficher pour ses
+interlocuteurs, puis l’adresse mail académique, sous la forme prénom.nom@ac-académie.fr.
+
+Si vous ne l'avez pas encore modifié, le mot de passe est votre NUMEN.
+
+
+Ensuite, il existe deux configurations possibles pour les messages entrants : POP et IMAP. Et
+il est très important de bien comprendre la différence. Vous êtes prêts? Concentrez-vous
+bien!
+
+Dans la configuration POP, les messages sont déplacés sur l’ordinateur, la tablette ou le
+smartphone, ce qui signifie qu’ils sont effacés du serveur du rectorat. Ce n’est donc pas une
+configuration recommandée.
+
+Dans la configuration IMAP, le client de messagerie est synchronisé avec le webmail de
+l’académie et, donc, les mails sont présents à la fois sur le serveur du rectorat et sur
+l’ordinateur, la tablette ou le smartphone. Cela permet d’accéder à tous ses messages,
+même anciens, depuis n’importe quel ordinateur ou téléphone.
+
+Revenons à l’écran de configuration. On choisit donc le protocole IMAP pour le serveur
+entrant.
+
+Le nom d’hôte du serveur est généralement l’url du webmail académique. En cas de doute,
+des sites Internet fournissent ces informations pour chaque académie.
+
+Il faut sélectionner le port 993 et une connexion sécurisée de type SSL/TLS, puis saisir
+l’identifiant académique : première lettre du prénom, suivie du nom.
+
+Pour les courriers sortants, il faut paramétrer la configuration SMTP du client de messagerie.
+Cela permettra d’envoyer des messages en utilisant l’adresse académique à condition de la
+sélectionner avant l’envoi.
+
+L’adresse SMTP est généralement de la forme smtp.ac-(le nom de l’académie).fr. Pour le
+type de connexion sécurisée, ce sera TLS ou STARTTLS et le port : 587 ou 465, selon les
+académies. Ces informations sont également accessibles sur Internet.
+
+L’identifiant du serveur sortant est le même que celui du serveur entrant.
+
+Cliquez sur « Terminer ». Bravo! Le client de messagerie est maintenant configuré!
+
+Vous pouvez maintenant basculer d’une boîte mail à l’autre en toute simplicité!
+
+## Crédits
+
+- **Scénario** : Nicolas Sedel, Corentine Gasquet, Laurent Gaudin, Pascal Pagny
+- **Direction de publication** : Marie-Caroline Missir
+- **Production** : Réseau Canopé
+- **Partenariat** : Pix
+Ressource produite avec le soutien du ministère de l’Éducation nationale et de la Jeunesse

--- a/content/edu/connaitre-des-applications-a-videoprojeter-pour-animer-et-gerer-sa-classe.json
+++ b/content/edu/connaitre-des-applications-a-videoprojeter-pour-animer-et-gerer-sa-classe.json
@@ -1,9 +1,0 @@
-{
-  "area" : "Domaine 3",
-  "title": "Connaître des applications à vidéoprojeter pour animer et gérer sa classe",
-  "description": "Tirage au sort, chronomètre, QR code, fichier audio : beaucoup d'outils existent de manière indépendante. Certaines applications centralisent toutes ces fonctionnalités pour permettre d'animer, de gérer des activités et les différents moments d'un cours. Les détails dans cette vidéo !",
-  "videoEmbedSrc": "https://tube.reseau-canope.fr/videos/embed/b83d2ab8-e18f-4156-9eda-8a49f8a59de9",
-  "videoDLHref": "https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/b83d2ab8-e18f-4156-9eda-8a49f8a59de9-1080-fragmented.mp4",
-  "fichePdfHref": "",
-  "transcriptPdfHref": ""
-}

--- a/content/edu/connaitre-des-applications-a-videoprojeter-pour-animer-et-gerer-sa-classe.md
+++ b/content/edu/connaitre-des-applications-a-videoprojeter-pour-animer-et-gerer-sa-classe.md
@@ -1,0 +1,7 @@
+---
+area: Domaine 3
+title: Connaître des applications à vidéoprojeter pour animer et gérer sa classe
+description: "Tirage au sort, chronomètre, QR code, fichier audio : beaucoup d'outils existent de manière indépendante. Certaines applications centralisent toutes ces fonctionnalités pour permettre d'animer, de gérer des activités et les différents moments d'un cours. Les détails dans cette vidéo !"
+videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/b83d2ab8-e18f-4156-9eda-8a49f8a59de9
+videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/b83d2ab8-e18f-4156-9eda-8a49f8a59de9-1080-fragmented.mp4
+---

--- a/content/edu/connaitre-des-outils-de-quiz-en-ligne.json
+++ b/content/edu/connaitre-des-outils-de-quiz-en-ligne.json
@@ -1,9 +1,0 @@
-{
-  "area" : "Domaine 3",
-  "title": "Connaître des outils de quiz en ligne",
-  "description": "Pour obtenir facilement et en temps réel les résultats d'une classe à un exercice, un quiz en ligne constitue un précieux allié. Mais quel outil de quiz choisir ? Des éléments de réponse dans cette vidéo !",
-  "videoEmbedSrc": "https://tube.reseau-canope.fr/videos/embed/2fc37e8d-860d-4789-a092-e6ca3b113943",
-  "videoDLHref": "https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/2fc37e8d-860d-4789-a092-e6ca3b113943-1080-fragmented.mp4",
-  "fichePdfHref": "",
-  "transcriptPdfHref": ""
-}

--- a/content/edu/connaitre-des-outils-de-quiz-en-ligne.md
+++ b/content/edu/connaitre-des-outils-de-quiz-en-ligne.md
@@ -1,0 +1,7 @@
+---
+area: Domaine 3
+title: Connaître des outils de quiz en ligne
+description: Pour obtenir facilement et en temps réel les résultats d'une classe à un exercice, un quiz en ligne constitue un précieux allié. Mais quel outil de quiz choisir ? Des éléments de réponse dans cette vidéo !
+videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/2fc37e8d-860d-4789-a092-e6ca3b113943
+videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/2fc37e8d-860d-4789-a092-e6ca3b113943-1080-fragmented.mp4
+---

--- a/content/edu/identifier-des-sources-de-veille-incontournables.json
+++ b/content/edu/identifier-des-sources-de-veille-incontournables.json
@@ -1,9 +1,0 @@
-{
-  "area" : "Domaine 1",
-  "title": "Identifier des sources de veille incontournables",
-  "description": "Pour éviter l'infobésité, la sélection de ses sources de veille est primordial. Dans cette vidéo, quelques sources de veille importantes de la sphère éducative qui peuvent vous intéresser !",
-  "videoEmbedSrc": "https://tube.reseau-canope.fr/videos/embed/b456fcdb-64d5-425e-8ff2-c023e9cb9543",
-  "videoDLHref": "https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/b456fcdb-64d5-425e-8ff2-c023e9cb9543-1080-fragmented.mp4",
-  "fichePdfHref": "",
-  "transcriptPdfHref": ""
-}

--- a/content/edu/identifier-des-sources-de-veille-incontournables.md
+++ b/content/edu/identifier-des-sources-de-veille-incontournables.md
@@ -1,0 +1,7 @@
+---
+area: Domaine 1
+title: Identifier des sources de veille incontournables
+description: Pour éviter l'infobésité, la sélection de ses sources de veille est primordial. Dans cette vidéo, quelques sources de veille importantes de la sphère éducative qui peuvent vous intéresser !
+videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/b456fcdb-64d5-425e-8ff2-c023e9cb9543
+videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/b456fcdb-64d5-425e-8ff2-c023e9cb9543-1080-fragmented.mp4
+---

--- a/content/edu/la-classe-inversee.json
+++ b/content/edu/la-classe-inversee.json
@@ -1,9 +1,0 @@
-{
-  "area" : "Domaine 3",
-  "title": "La classe inversée",
-  "description": "La classe inversée est souvent présentée comme un moyen de responsabiliser les élèves, de les rendre actifs tout en leur accordant une grande autonomie. Les détails dans cette vidéo !",
-  "videoEmbedSrc": "https://tube.reseau-canope.fr/videos/embed/9d109c46-311c-49ce-826e-406581233be0",
-  "videoDLHref": "https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/9d109c46-311c-49ce-826e-406581233be0-1080-fragmented.mp4",
-  "fichePdfHref": "",
-  "transcriptPdfHref": ""
-}

--- a/content/edu/la-classe-inversee.md
+++ b/content/edu/la-classe-inversee.md
@@ -1,0 +1,7 @@
+---
+area: Domaine 3
+title: La classe inversée
+description: La classe inversée est souvent présentée comme un moyen de responsabiliser les élèves, de les rendre actifs tout en leur accordant une grande autonomie. Les détails dans cette vidéo !
+videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/9d109c46-311c-49ce-826e-406581233be0
+videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/9d109c46-311c-49ce-826e-406581233be0-1080-fragmented.mp4
+---

--- a/content/edu/le-cadre-de-reference-des-competences-numeriques.json
+++ b/content/edu/le-cadre-de-reference-des-competences-numeriques.json
@@ -1,9 +1,0 @@
-{
-  "area" : "Domaine 5",
-  "title": "Le Cadre de référence des compétences numériques (CRCN)",
-  "description": "Inspiré du cadre européen DigComp, le Cadre de référence des compétences numériques (CRCN) structure les savoirs et savoir-faire relatifs au numérique pour aider les enseignants et leurs élèves au développement de ces compétences dans le cadre scolaire. Prêt à en savoir encore plus sur le CRCN ?",
-  "videoEmbedSrc": "https://tube.reseau-canope.fr/videos/embed/1d82b613-ee83-4b08-895d-61a10aa8ecdb",
-  "videoDLHref": "https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/1d82b613-ee83-4b08-895d-61a10aa8ecdb-1080-fragmented.mp4",
-  "fichePdfHref": "",
-  "transcriptPdfHref": ""
-}

--- a/content/edu/le-cadre-de-reference-des-competences-numeriques.md
+++ b/content/edu/le-cadre-de-reference-des-competences-numeriques.md
@@ -1,0 +1,7 @@
+---
+area: Domaine 5
+title: Le Cadre de référence des compétences numériques (CRCN)
+description: Inspiré du cadre européen DigComp, le Cadre de référence des compétences numériques (CRCN) structure les savoirs et savoir-faire relatifs au numérique pour aider les enseignants et leurs élèves au développement de ces compétences dans le cadre scolaire. Prêt à en savoir encore plus sur le CRCN ?
+videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/1d82b613-ee83-4b08-895d-61a10aa8ecdb
+videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/1d82b613-ee83-4b08-895d-61a10aa8ecdb-1080-fragmented.mp4
+---

--- a/content/edu/le-cahier-de-texte-numerique.json
+++ b/content/edu/le-cahier-de-texte-numerique.json
@@ -1,9 +1,0 @@
-{
-  "area" : "Domaine 5",
-  "title": "Le cahier de texte numérique",
-  "description": "Objet emblématique d'une classe, le cahier de texte est désormais au format numérique. Ce format permet d'en faire un outil partagé et qui présente de nouvelles fonctionnalités. Plus de détails dans cette vidéo !",
-  "videoEmbedSrc": "https://tube.reseau-canope.fr/videos/embed/d797ea7c-77f3-45fc-b47a-823cb63745b9",
-  "videoDLHref": "https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/d797ea7c-77f3-45fc-b47a-823cb63745b9-1080-fragmented.mp4",
-  "fichePdfHref": "",
-  "transcriptPdfHref": ""
-}

--- a/content/edu/le-cahier-de-texte-numerique.md
+++ b/content/edu/le-cahier-de-texte-numerique.md
@@ -1,0 +1,7 @@
+---
+area: Domaine 5
+title: Le cahier de texte numérique
+description: Objet emblématique d'une classe, le cahier de texte est désormais au format numérique. Ce format permet d'en faire un outil partagé et qui présente de nouvelles fonctionnalités. Plus de détails dans cette vidéo !
+videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/d797ea7c-77f3-45fc-b47a-823cb63745b9
+videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/d797ea7c-77f3-45fc-b47a-823cb63745b9-1080-fragmented.mp4
+---

--- a/content/edu/le-cyberharcelement.json
+++ b/content/edu/le-cyberharcelement.json
@@ -1,9 +1,0 @@
-{
-  "area" : "Domaine 1",
-  "title": "Le cyberharcèlement",
-  "description": "Malheureusement d'actualité, les situations de cyberharcèlement progressent en milieu scolaire. Comment lutter contre ces situations et accompagner les personnes concernées ?",
-  "videoEmbedSrc": "https://tube.reseau-canope.fr/videos/embed/ef2ca374-d224-4440-960c-69d335973a52",
-  "videoDLHref": "https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/ef2ca374-d224-4440-960c-69d335973a52-1080-fragmented.mp4",
-  "fichePdfHref": "",
-  "transcriptPdfHref": ""
-}

--- a/content/edu/le-cyberharcelement.md
+++ b/content/edu/le-cyberharcelement.md
@@ -1,0 +1,7 @@
+---
+area: Domaine 1
+title: Le cyberharcèlement
+description: Malheureusement d'actualité, les situations de cyberharcèlement progressent en milieu scolaire. Comment lutter contre ces situations et accompagner les personnes concernées ?
+videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/ef2ca374-d224-4440-960c-69d335973a52
+videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/ef2ca374-d224-4440-960c-69d335973a52-1080-fragmented.mp4
+---

--- a/content/edu/le-droit-a-l-image-des-eleves.json
+++ b/content/edu/le-droit-a-l-image-des-eleves.json
@@ -1,9 +1,0 @@
-{
-  "area" : "Domaine 1",
-  "title": "Le droit à l'image des élèves",
-  "description": "Comme tout citoyen, les élèves disposent d'un droit à l'image. Comment le respecter au mieux en tant qu'enseignant ? C'est ce que nous allons voir dans cette vidéo.",
-  "videoEmbedSrc": "https://tube.reseau-canope.fr/videos/embed/21e4730e-59f2-4363-bb8f-7425e4031cc0",
-  "videoDLHref": "https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/21e4730e-59f2-4363-bb8f-7425e4031cc0-1080-fragmented.mp4",
-  "fichePdfHref": "",
-  "transcriptPdfHref": ""
-}

--- a/content/edu/le-droit-a-l-image-des-eleves.md
+++ b/content/edu/le-droit-a-l-image-des-eleves.md
@@ -1,0 +1,7 @@
+---
+area: Domaine 1
+title: Le droit à l'image des élèves
+description: Comme tout citoyen, les élèves disposent d'un droit à l'image. Comment le respecter au mieux en tant qu'enseignant ? C'est ce que nous allons voir dans cette vidéo.
+videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/21e4730e-59f2-4363-bb8f-7425e4031cc0
+videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/21e4730e-59f2-4363-bb8f-7425e4031cc0-1080-fragmented.mp4
+---

--- a/content/edu/le-droit-d-auteur-des-eleves.json
+++ b/content/edu/le-droit-d-auteur-des-eleves.json
@@ -1,9 +1,0 @@
-{
-  "area" : "Domaine 2",
-  "title": "Le droit d'auteur des élèves",
-  "description": "Les élèves disposent, comme tout citoyen, d'un droit d'auteur sur leurs créations produites à l'école. Comment respecter au mieux ce droit en tant qu'enseignant ?",
-  "videoEmbedSrc": "https://tube.reseau-canope.fr/videos/embed/ef12284a-5da4-478f-83fa-51db88b9ce9d",
-  "videoDLHref": "https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/ef12284a-5da4-478f-83fa-51db88b9ce9d-1080-fragmented.mp4",
-  "fichePdfHref": "",
-  "transcriptPdfHref": ""
-}

--- a/content/edu/le-droit-d-auteur-des-eleves.md
+++ b/content/edu/le-droit-d-auteur-des-eleves.md
@@ -1,0 +1,7 @@
+---
+area: Domaine 2
+title: Le droit d'auteur des élèves
+description: Les élèves disposent, comme tout citoyen, d'un droit d'auteur sur leurs créations produites à l'école. Comment respecter au mieux ce droit en tant qu'enseignant ?
+videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/ef12284a-5da4-478f-83fa-51db88b9ce9d
+videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/ef12284a-5da4-478f-83fa-51db88b9ce9d-1080-fragmented.mp4
+---

--- a/content/edu/le-modele-samr-pour-integrer-le-numerique-dans-la-pedagogie.json
+++ b/content/edu/le-modele-samr-pour-integrer-le-numerique-dans-la-pedagogie.json
@@ -1,9 +1,0 @@
-{
-  "area" : "Domaine 1",
-  "title": "Le modèle SAMR pour intégrer le numérique dans la pédagogie",
-  "description": "Le modèle théorique SAMR est issu de la recherche. Il permet d'interroger l'usage du numérique dans une activité pédagogique afin d'estimer dans quelle mesure cette utilisation modifie les tâches menées par les élèves. Plus d'informations dans cette vidéo !",
-  "videoEmbedSrc": "https://tube.reseau-canope.fr/videos/embed/fb9ee01b-1d22-404d-8496-d14c0c698796",
-  "videoDLHref": "https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/fb9ee01b-1d22-404d-8496-d14c0c698796-1080-fragmented.mp4",
-  "fichePdfHref": "",
-  "transcriptPdfHref": ""
-}

--- a/content/edu/le-modele-samr-pour-integrer-le-numerique-dans-la-pedagogie.md
+++ b/content/edu/le-modele-samr-pour-integrer-le-numerique-dans-la-pedagogie.md
@@ -1,0 +1,7 @@
+---
+area: Domaine 1
+title: Le modèle SAMR pour intégrer le numérique dans la pédagogie
+description: Le modèle théorique SAMR est issu de la recherche. Il permet d'interroger l'usage du numérique dans une activité pédagogique afin d'estimer dans quelle mesure cette utilisation modifie les tâches menées par les élèves. Plus d'informations dans cette vidéo !
+videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/fb9ee01b-1d22-404d-8496-d14c0c698796
+videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/fb9ee01b-1d22-404d-8496-d14c0c698796-1080-fragmented.mp4
+---

--- a/content/edu/le-modele-tpack-pour-integrer-le-numerique-dans-la-pedagogie.json
+++ b/content/edu/le-modele-tpack-pour-integrer-le-numerique-dans-la-pedagogie.json
@@ -1,9 +1,0 @@
-{
-  "area" : "Domaine 1",
-  "title": "Le modèle TPaCK pour intégrer le numérique dans la pédagogie",
-  "description": "Dans leur activité professionnelle, les enseignants sont amenés à mobiliser des compétences pédagogiques, disciplinaires et techniques. Tel est le cadre proposé par le modèle théorique TPaCK afin de les aider à enrichir l'analyse réflexive de leurs pratiques.",
-  "videoEmbedSrc": "https://tube.reseau-canope.fr/videos/embed/11823461-ed6a-4607-8b7a-e39ba906c481",
-  "videoDLHref": "https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/11823461-ed6a-4607-8b7a-e39ba906c481-1080-fragmented.mp4",
-  "fichePdfHref": "",
-  "transcriptPdfHref": ""
-}

--- a/content/edu/le-modele-tpack-pour-integrer-le-numerique-dans-la-pedagogie.md
+++ b/content/edu/le-modele-tpack-pour-integrer-le-numerique-dans-la-pedagogie.md
@@ -1,0 +1,7 @@
+---
+area: Domaine 1
+title: Le modèle TPaCK pour intégrer le numérique dans la pédagogie
+description: Dans leur activité professionnelle, les enseignants sont amenés à mobiliser des compétences pédagogiques, disciplinaires et techniques. Tel est le cadre proposé par le modèle théorique TPaCK afin de les aider à enrichir l'analyse réflexive de leurs pratiques.
+videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/11823461-ed6a-4607-8b7a-e39ba906c481
+videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/11823461-ed6a-4607-8b7a-e39ba906c481-1080-fragmented.mp4
+---

--- a/content/edu/le-principe-de-l-exception-pedagogique.json
+++ b/content/edu/le-principe-de-l-exception-pedagogique.json
@@ -1,9 +1,0 @@
-{
-  "area" : "Domaine 2",
-  "title": "Le principe de l'exception pédagogique",
-  "description": "Pas toujours facile de respecter la propriété intellectuelle de chacun lors de la conception de supports pédagogiques. L'exception pédagogique a été pensée pour permettre aux enseignants de se saisir de ressources existantes, sous certaines conditions. Tous les détails dans la vidéo !",
-  "videoEmbedSrc": "https://tube.reseau-canope.fr/videos/embed/48dcc19b-31fb-45a8-acb0-4304d24eaf22",
-  "videoDLHref": "https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/48dcc19b-31fb-45a8-acb0-4304d24eaf22-1080-fragmented.mp4",
-  "fichePdfHref": "",
-  "transcriptPdfHref": ""
-}

--- a/content/edu/le-principe-de-l-exception-pedagogique.md
+++ b/content/edu/le-principe-de-l-exception-pedagogique.md
@@ -1,0 +1,7 @@
+---
+area: Domaine 2
+title: Le principe de l'exception pédagogique
+description: Pas toujours facile de respecter la propriété intellectuelle de chacun lors de la conception de supports pédagogiques. L'exception pédagogique a été pensée pour permettre aux enseignants de se saisir de ressources existantes, sous certaines conditions. Tous les détails dans la vidéo !
+videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/48dcc19b-31fb-45a8-acb0-4304d24eaf22
+videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/48dcc19b-31fb-45a8-acb0-4304d24eaf22-1080-fragmented.mp4
+---

--- a/content/edu/le-rgpd-en-milieu-scolaire.json
+++ b/content/edu/le-rgpd-en-milieu-scolaire.json
@@ -1,9 +1,0 @@
-{
-  "area" : "Domaine 1",
-  "title": "Le RGPD en milieu scolaire",
-  "description": "Au programme de cette vidéo : une présentation du RGPD et le rôle des personnels des établissements scolaires.",
-  "videoEmbedSrc": "https://tube.reseau-canope.fr/videos/embed/80dcdd6b-5c58-4846-9943-1c0d8f6866b9",
-  "videoDLHref": "https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/80dcdd6b-5c58-4846-9943-1c0d8f6866b9-1080-fragmented.mp4",
-  "fichePdfHref": "",
-  "transcriptPdfHref": ""
-}

--- a/content/edu/le-rgpd-en-milieu-scolaire.md
+++ b/content/edu/le-rgpd-en-milieu-scolaire.md
@@ -1,0 +1,7 @@
+---
+area: Domaine 1
+title: Le RGPD en milieu scolaire
+description: 'Au programme de cette vidéo : une présentation du RGPD et le rôle des personnels des établissements scolaires.'
+videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/80dcdd6b-5c58-4846-9943-1c0d8f6866b9
+videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/80dcdd6b-5c58-4846-9943-1c0d8f6866b9-1080-fragmented.mp4
+---

--- a/content/edu/le-site-cap-ecole-inclusive.json
+++ b/content/edu/le-site-cap-ecole-inclusive.json
@@ -1,9 +1,0 @@
-{
-  "area" : "Domaine 4",
-  "title": "Le site Cap école inclusive",
-  "description": "Intéressés par des grilles pour analyser les besoins particuliers de vos élèves ou par une cartographie des acteurs de l'école inclusive en France : le site Cap école inclusive est fait pour vous.",
-  "videoEmbedSrc": "https://tube.reseau-canope.fr/videos/embed/b2b7cf75-69b2-40db-a35c-164457affaaa",
-  "videoDLHref": "https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/b2b7cf75-69b2-40db-a35c-164457affaaa-1080-fragmented.mp4",
-  "fichePdfHref": "",
-  "transcriptPdfHref": ""
-}

--- a/content/edu/le-site-cap-ecole-inclusive.md
+++ b/content/edu/le-site-cap-ecole-inclusive.md
@@ -1,0 +1,7 @@
+---
+area: Domaine 4
+title: Le site Cap école inclusive
+description: "Intéressés par des grilles pour analyser les besoins particuliers de vos élèves ou par une cartographie des acteurs de l'école inclusive en France : le site Cap école inclusive est fait pour vous."
+videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/b2b7cf75-69b2-40db-a35c-164457affaaa
+videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/b2b7cf75-69b2-40db-a35c-164457affaaa-1080-fragmented.mp4
+---

--- a/content/edu/learning-analytics-et-intelligence-artificielle-dans-l-education.json
+++ b/content/edu/learning-analytics-et-intelligence-artificielle-dans-l-education.json
@@ -1,9 +1,0 @@
-{
-  "area" : "Domaine 3",
-  "title": "Learning analytics et intelligence artificielle dans l'éducation",
-  "description": "Les données éducatives se sont, comme toutes les autres données, massifiées ces dernières années. Comment sont-elles utilisées par le monde de la recherche ? Que nous apprennent-elles ?",
-  "videoEmbedSrc": "https://tube.reseau-canope.fr/videos/embed/d66e9416-39ee-4d25-bac8-80552dcc463b",
-  "videoDLHref": "https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/d66e9416-39ee-4d25-bac8-80552dcc463b-1080-fragmented.mp4",
-  "fichePdfHref": "",
-  "transcriptPdfHref": ""
-}

--- a/content/edu/learning-analytics-et-intelligence-artificielle-dans-l-education.md
+++ b/content/edu/learning-analytics-et-intelligence-artificielle-dans-l-education.md
@@ -1,0 +1,7 @@
+---
+area: Domaine 3
+title: Learning analytics et intelligence artificielle dans l'éducation
+description: Les données éducatives se sont, comme toutes les autres données, massifiées ces dernières années. Comment sont-elles utilisées par le monde de la recherche ? Que nous apprennent-elles ?
+videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/d66e9416-39ee-4d25-bac8-80552dcc463b
+videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/d66e9416-39ee-4d25-bac8-80552dcc463b-1080-fragmented.mp4
+---

--- a/content/edu/les-acteurs-de-la-formation-en-ligne-des-enseignants.json
+++ b/content/edu/les-acteurs-de-la-formation-en-ligne-des-enseignants.json
@@ -1,9 +1,0 @@
-{
-  "area" : "Domaine 1",
-  "title": "Les acteurs de la formation en ligne des enseignants",
-  "description": "De nombreuses formations en ligne sont proposées par des acteurs du monde éducatif. Découvrez-les dans cette vidéo !",
-  "videoEmbedSrc": "https://tube.reseau-canope.fr/videos/embed/67df24ff-e146-45ae-8eca-562bce282d50",
-  "videoDLHref": "https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/67df24ff-e146-45ae-8eca-562bce282d50-1080-fragmented.mp4",
-  "fichePdfHref": "",
-  "transcriptPdfHref": ""
-}

--- a/content/edu/les-acteurs-de-la-formation-en-ligne-des-enseignants.md
+++ b/content/edu/les-acteurs-de-la-formation-en-ligne-des-enseignants.md
@@ -1,0 +1,7 @@
+---
+area: Domaine 1
+title: Les acteurs de la formation en ligne des enseignants
+description: De nombreuses formations en ligne sont proposées par des acteurs du monde éducatif. Découvrez-les dans cette vidéo !
+videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/67df24ff-e146-45ae-8eca-562bce282d50
+videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/67df24ff-e146-45ae-8eca-562bce282d50-1080-fragmented.mp4
+---

--- a/content/edu/les-acteurs-institutionnels-du-numerique-educatif-dans-le-2nd-degre.json
+++ b/content/edu/les-acteurs-institutionnels-du-numerique-educatif-dans-le-2nd-degre.json
@@ -1,9 +1,0 @@
-{
- "area" : "Domaine 1",
-  "title": "Les acteurs institutionnels du numérique éducatif dans le 2nd degré",
-  "description": "Découvrez dans cette vidéo l'ensemble des acteurs au sein de l'Éducation nationale qui ont des missions relatives au numérique éducatif dans le second degré.",
-  "videoEmbedSrc": "https://tube.reseau-canope.fr/videos/embed/b2d55662-aae2-41f3-8fa0-2b0e6ad4de87",
-  "videoDLHref": "https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/b2d55662-aae2-41f3-8fa0-2b0e6ad4de87-1080-fragmented.mp4",
-  "fichePdfHref": "",
-  "transcriptPdfHref": ""
-}

--- a/content/edu/les-acteurs-institutionnels-du-numerique-educatif-dans-le-2nd-degre.md
+++ b/content/edu/les-acteurs-institutionnels-du-numerique-educatif-dans-le-2nd-degre.md
@@ -1,0 +1,70 @@
+---
+area : Domaine 1
+title: Les acteurs institutionnels du numérique éducatif dans le 2nd degré
+description: Découvrez dans cette vidéo l'ensemble des acteurs au sein de l'Éducation nationale qui ont des missions relatives au numérique éducatif dans le second degré.
+videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/b2d55662-aae2-41f3-8fa0-2b0e6ad4de87
+videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/b2d55662-aae2-41f3-8fa0-2b0e6ad4de87-1080-fragmented.mp4
+---
+
+## Script
+
+RUPN, responsable d’affectation GAR, DANE ou DRANE, IAN... Ils sont nombreux à
+contribuer au développement du numérique éducatif. C’est parfois difficile de s’y retrouver.
+Alors, découvrons ensemble le « Qui fait quoi » du numérique éducatif dans l’Éducation
+nationale. Quel est le rôle du référent numérique? Du responsable d’affectation GAR?
+Des DRANE? Et des IAN?
+
+En tant qu’enseignant, le référent pour les ressources et usages pédagogiques numériques –
+ou RUPN – est sans doute l’acteur institutionnel avec lequel vous interagissez le plus
+souvent. Désigné par le chef d’établissement, sur la base d’une lettre de mission, il conseille
+l’équipe de direction sur la place du numérique dans le projet d’établissement. Il est là
+notamment pour recenser les besoins en formation des enseignants et les accompagner
+dans leurs usages pédagogiques du numérique. Par exemple, un professeur d’histoire-
+géographie veut réaliser une promenade interactive sur le Paris de la Commune. Il s’adresse
+au référent numérique pour connaître les équipements disponibles dans l’établissement,
+savoir quels logiciels seront les plus adaptés et se former à leur prise en main.
+
+Dans les régions où le numérique est massivement déployé, le responsable d’affectation
+GAR (gestionnaire d'accès aux ressources) est un acteur incontournable au lycée. Ce rôle
+peut être assuré par le chef d’établissement mais il est généralement délégué à un ou
+plusieurs enseignants. Le GAR permet aux élèves et aux enseignants d’accéder à leurs
+ressources en utilisant un seul identifiant, _via_ leur ENT, tout en protégeant leurs données
+personnelles. Le responsable d’affectation GAR distribue par exemple les manuels
+numériques aux enseignants et aux élèves.
+
+
+Réseau Canopé, 2022 - CC BY-NC-ND 4.0 2
+
+Le délégué au numérique, de région ou d’académie, est chargé auprès de chaque recteur de
+proposer, de mettre en œuvre et évaluer une stratégie pour le numérique éducatif. À la
+demande du chef d’établissement, il peut par exemple appuyer une demande de matériel
+auprès de la collectivité territoriale qui assure le financement des équipements numériques.
+Il joue aussi un rôle de prescripteur en matière de formation au numérique en collaboration
+avec les Écoles académiques de la formation continue (EAFC), les corps d’inspection et
+Réseau Canopé. Il remplit une mission d’animation des Interlocuteurs académiques pour le
+numérique et des référents numériques. Il pilote le déploiement des projets numériques
+comme le dispositif TNE (Territoires numériques éducatifs). Enfin, il aide à mettre en place
+des partenariats avec l'université et les entreprises du numérique éducatif. Par exemple, il
+intervient dans le cadre du partenariat d’innovation « Intelligence artificielle ».
+
+Sous l’impulsion de la Direction du numérique pour l’éducation et en étroite collaboration
+avec l’inspection générale, les Interlocuteurs académiques pour le numérique – les IAN -
+sont des relais locaux pour leur discipline. 33 experts disciplinaires de la DNE animent un
+réseau de 450 IAN. Les IAN valorisent des projets développés dans l’académie, par exemple
+les publications Éduscol, les scénarios Édubase ou les lettres Édu_Num. Ils participent aussi
+aux actions engagées par le Ministère, comme les Travaux académiques mutualisés.
+
+Référent numérique, Responsable d’affectation GAR, Délégué au numérique éducatif de
+région ou d’académie, Interlocuteur académique pour le numérique : de nombreux acteurs
+sont présents à différents niveaux et œuvrent pour vous accompagner sur la dimension
+numérique de votre métier. Ils apportent une aide au quotidien sur le terrain, s’occupent de
+la gestion de ressources, de la formation, de la mutualisation de pratiques et exercent une
+veille technologique. Grâce à eux, vous voilà paré à décrypter la matrice!
+
+## Crédits
+
+- **Scénario** : Nicolas Sedel, Corentine Gasquet
+- **Direction de publication** : Marie-Caroline Missir
+- **Production** : Réseau Canopé
+- **Partenariat** : Pix
+Ressource produite avec le soutien du ministère de l’Éducation nationale et de la Jeunesse

--- a/content/edu/les-donnees-a-caractere-personnel-en-milieu-scolaire.json
+++ b/content/edu/les-donnees-a-caractere-personnel-en-milieu-scolaire.json
@@ -1,9 +1,0 @@
-{
-  "area" : "Domaine 1",
-  "title": "Les données à caractère personnel en milieu scolaire",
-  "description": "Au programme de cette vidéo : définir les données personnelles et découvrir les enjeux associés en contexte scolaire.",
-  "videoEmbedSrc": "https://tube.reseau-canope.fr/videos/embed/04158691-0e9e-40cd-b777-925e2f83c535",
-  "videoDLHref": "https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/04158691-0e9e-40cd-b777-925e2f83c535-1080-fragmented.mp4",
-  "fichePdfHref": "",
-  "transcriptPdfHref": ""
-}

--- a/content/edu/les-donnees-a-caractere-personnel-en-milieu-scolaire.md
+++ b/content/edu/les-donnees-a-caractere-personnel-en-milieu-scolaire.md
@@ -1,0 +1,7 @@
+---
+area: Domaine 1
+title: Les données à caractère personnel en milieu scolaire
+description: 'Au programme de cette vidéo : définir les données personnelles et découvrir les enjeux associés en contexte scolaire.'
+videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/04158691-0e9e-40cd-b777-925e2f83c535
+videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/04158691-0e9e-40cd-b777-925e2f83c535-1080-fragmented.mp4
+---

--- a/content/edu/les-erun-acteurs-du-numerique-educatif.json
+++ b/content/edu/les-erun-acteurs-du-numerique-educatif.json
@@ -1,9 +1,0 @@
-{
-  "area" : "Domaine 1",
-  "title": "Les eRUN, acteurs du numérique éducatif",
-  "description": "Les eRUN sont des acteurs incontournables du numérique dans le premier degré. Découvez-en plus concernant leurs missions et leurs responsabilités en visionnant cette vidéo !",
-  "videoEmbedSrc": "https://tube.reseau-canope.fr/videos/embed/8e1c457b-4bc8-44b2-b6e6-cbac4f611442",
-  "videoDLHref": "https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/8e1c457b-4bc8-44b2-b6e6-cbac4f611442-1080-fragmented.mp4",
-  "fichePdfHref": "",
-  "transcriptPdfHref": ""
-}

--- a/content/edu/les-erun-acteurs-du-numerique-educatif.md
+++ b/content/edu/les-erun-acteurs-du-numerique-educatif.md
@@ -1,0 +1,7 @@
+---
+area: Domaine 1
+title: Les eRUN, acteurs du numérique éducatif
+description: Les eRUN sont des acteurs incontournables du numérique dans le premier degré. Découvez-en plus concernant leurs missions et leurs responsabilités en visionnant cette vidéo !
+videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/8e1c457b-4bc8-44b2-b6e6-cbac4f611442
+videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/8e1c457b-4bc8-44b2-b6e6-cbac4f611442-1080-fragmented.mp4
+---

--- a/content/edu/les-fonctionnalites-de-retroaction-des-outils-de-quiz-en-ligne.json
+++ b/content/edu/les-fonctionnalites-de-retroaction-des-outils-de-quiz-en-ligne.json
@@ -1,9 +1,0 @@
-{
-  "area" : "Domaine 3",
-  "title": "Les fonctionnalités de rétroaction des outils de quiz en ligne",
-  "description": "Pour guider un élève lors d'un quiz en ligne, rien de mieux qu'une rétroaction (feedback). Selon l'outil que vous choisirez, vous pourrez plus ou moins personnaliser et détailler vos rétroactions. ",
-  "videoEmbedSrc": "https://tube.reseau-canope.fr/videos/embed/bf1c9c80-1d0a-4f99-9de5-dc488ef9e24f",
-  "videoDLHref": "https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/bf1c9c80-1d0a-4f99-9de5-dc488ef9e24f-1080-fragmented.mp4",
-  "fichePdfHref": "",
-  "transcriptPdfHref": ""
-}

--- a/content/edu/les-fonctionnalites-de-retroaction-des-outils-de-quiz-en-ligne.md
+++ b/content/edu/les-fonctionnalites-de-retroaction-des-outils-de-quiz-en-ligne.md
@@ -1,0 +1,7 @@
+---
+area: Domaine 3
+title: Les fonctionnalités de rétroaction des outils de quiz en ligne
+description: Pour guider un élève lors d'un quiz en ligne, rien de mieux qu'une rétroaction (feedback). Selon l'outil que vous choisirez, vous pourrez plus ou moins personnaliser et détailler vos rétroactions.
+videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/bf1c9c80-1d0a-4f99-9de5-dc488ef9e24f
+videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/bf1c9c80-1d0a-4f99-9de5-dc488ef9e24f-1080-fragmented.mp4
+---

--- a/content/edu/les-lieux-d-echange-en-ligne-entre-professionnels.json
+++ b/content/edu/les-lieux-d-echange-en-ligne-entre-professionnels.json
@@ -1,9 +1,0 @@
-{
-  "area" : "Domaine 1",
-  "title": "Les lieux d'échange en ligne entre professionnels",
-  "description": "De nombreux enseignants échangent en ligne, autour par exemple d'activités, de conseils pratiques ou encore d'idées de projet. Voici dans cette vidéo quelques lieux d'échange en ligne qui peuvent vous intéresser !",
-  "videoEmbedSrc": "https://tube.reseau-canope.fr/videos/embed/d61113c3-6eeb-479b-a68a-3788e7b60be4",
-  "videoDLHref": "https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/d61113c3-6eeb-479b-a68a-3788e7b60be4-1080-fragmented.mp4",
-  "fichePdfHref": "",
-  "transcriptPdfHref": ""
-}

--- a/content/edu/les-lieux-d-echange-en-ligne-entre-professionnels.md
+++ b/content/edu/les-lieux-d-echange-en-ligne-entre-professionnels.md
@@ -1,0 +1,7 @@
+---
+area: Domaine 1
+title: Les lieux d'échange en ligne entre professionnels
+description: De nombreux enseignants échangent en ligne, autour par exemple d'activités, de conseils pratiques ou encore d'idées de projet. Voici dans cette vidéo quelques lieux d'échange en ligne qui peuvent vous intéresser !
+videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/d61113c3-6eeb-479b-a68a-3788e7b60be4
+videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/d61113c3-6eeb-479b-a68a-3788e7b60be4-1080-fragmented.mp4
+---

--- a/content/edu/les-referents-numeriques-pour-le-second-degre.json
+++ b/content/edu/les-referents-numeriques-pour-le-second-degre.json
@@ -1,9 +1,0 @@
-{
-  "area" : "Domaine 1",
-  "title": "Les référents numériques pour le second degré",
-  "description": "Dans cette vidéo, (re-)découvrez le rôle et les missions d'un référent pour les ressources et usages pédagogiques numériques.",
-  "videoEmbedSrc": "https://tube.reseau-canope.fr/videos/embed/f46785b1-9043-4770-8b51-761b54f84988",
-  "videoDLHref": "https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/f46785b1-9043-4770-8b51-761b54f84988-1080-fragmented.mp4",
-  "fichePdfHref": "",
-  "transcriptPdfHref": ""
-}

--- a/content/edu/les-referents-numeriques-pour-le-second-degre.md
+++ b/content/edu/les-referents-numeriques-pour-le-second-degre.md
@@ -1,0 +1,76 @@
+---
+area : Domaine 1
+title: Les référents numériques pour le second degré
+description: Dans cette vidéo, (re-)découvrez le rôle et les missions d'un référent pour les ressources et usages pédagogiques numériques.
+videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/f46785b1-9043-4770-8b51-761b54f84988
+videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/f46785b1-9043-4770-8b51-761b54f84988-1080-fragmented.mp4
+---
+
+## Script
+
+Qu'il s’agisse de se former sur un nouveau logiciel, de s’initier à l’utilisation de l’ENT ou de
+lancer un projet de webradio au lycée, tout enseignant peut compter sur le soutien du
+référent numérique de son établissement, ou RUPN (Référent aux ressources et aux usages
+pédagogiques numériques).
+
+Tous les établissements du 2nd degré disposent d’un ou de plusieurs référents numériques.
+
+- Qu'est-ce qu’un référent numérique?
+- Quelles sont ses missions auprès du chef d’établissement, des enseignants et des collectivités?
+
+C’est ce que nous allons voir dans cette vidéo.
+
+« J’ai l’honneur de vous nommer référent. Voici votre lettre de mission. »
+
+C’est le chef d’établissement qui confie la mission de référent numérique à un ou plusieurs
+enseignants. Le référent reçoit une lettre de mission et une indemnité pour mission
+particulière. Il devient ainsi le relais local de la Délégation régionale au numérique pour
+l’éducation.
+
+Sa première mission consiste à conseiller l'équipe de direction sur la place du numérique
+dans le projet d’établissement. Il est là notamment pour recenser les besoins en formation.
+Par exemple, un chef d’établissement a besoin de matériel pour un projet particulier.
+Il demande conseil à la référente numérique de son établissement. Celle-ci va interroger ses
+collègues pour comprendre leurs usages. Quels sont les besoins en fonction de leurs
+projets? Quelles sont les difficultés rencontrées avec le matériel actuel?
+
+Dans le même temps, elle va comparer les équipements de l’établissement avec le nouveau
+matériel proposé par le département ou la région pour voir si le changement est utile. Grâce
+à ce travail sur les besoins existants et la pertinence d’acquérir un matériel plus récent, le
+chef d’établissement pourra décider de faire sa demande de renouvellement de dotation au
+département.
+
+Le référent numérique a pour seconde mission d’accompagner les enseignants de son
+établissement dans leur pratique pédagogique du numérique. Par exemple, Rosemarie,
+professeure d’anglais, prépare un séjour en Angleterre avec ses élèves de seconde. Pour
+travailler leur anglais aussi bien que leurs compétences numériques, elle prévoit de lancer
+un « Vlog voyage ». Rosemarie fait appel au référent pour l’aider à mettre en place son
+projet. Le référent dispose d’une expertise pédagogique. Si besoin, il peut aussi la mettre en
+relation avec les experts que sont les IAN ou la DRANE. Le référent peut conseiller Rosemarie
+sur le choix du matériel et des logiciels de montage vidéo. Il peut aussi la former à leur
+bonne utilisation. Comme il travaille en lien avec le Délégué à la protection des données
+académiques, il sensibilise Rosemarie à la sécurité de l'environnement informatique et aux
+respects des règles telles que le RGPD. Grâce à ce Vlog, les élèves ont développé de
+nouvelles compétences numériques.
+
+La troisième mission du référent numérique concerne la disponibilité des équipements. En
+lien avec la collectivité et le gestionnaire de l’établissement, il définit une procédure de
+remontée des signalements de pannes et bugs informatiques. Cela passe généralement par
+des tickets d’incident émis par les enseignants eux-mêmes. Donc attention aux confusions :
+le référent numérique n’assure pas la maintenance de la salle informatique, ni du parc
+informatique de l’établissement. Il n’a pas non plus l’accès administrateur. Enfin, selon les
+établissements, le référent numérique a aussi pour mission de participer à l’administration
+des ENT. Par exemple, il peut s’assurer que les élèves et les parents parviennent bien à se
+connecter, en organisant des actions d'information.
+
+Grâce à une veille active et régulière, le référent numérique joue donc un rôle central dans le
+projet d’établissement pour accompagner les enseignants sur les usages pédagogiques du
+numérique.
+
+## Crédits
+
+- **Scénario** : Nicolas Sedel, Corentine Gasquet, Murielle Tavarner
+- **Direction de publication** : Marie-Caroline Missir
+- **Production** : Réseau Canopé
+- **Partenariat** : Pix
+Ressource produite avec le soutien du ministère de l’Éducation nationale et de la Jeunesse

--- a/content/edu/les-systemes-robotises-de-telepresence.json
+++ b/content/edu/les-systemes-robotises-de-telepresence.json
@@ -1,9 +1,0 @@
-{
-  "area" : "Domaine 4",
-  "title": "Les systèmes robotisés de téléprésence",
-  "description": "Les systèmes robotisés de téléprésence permettent aux élèves empêchés de se rendre à l'école sur une longue période de suivre les cours et garder des liens avec ses camarades. Une vidéo pour en savoir plus.",
-  "videoEmbedSrc": "https://tube.reseau-canope.fr/videos/embed/4954a3c4-804d-4346-90b0-024a18d07674",
-  "videoDLHref": "https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/4954a3c4-804d-4346-90b0-024a18d07674-1080-fragmented.mp4",
-  "fichePdfHref": "",
-  "transcriptPdfHref": ""
-}

--- a/content/edu/les-systemes-robotises-de-telepresence.md
+++ b/content/edu/les-systemes-robotises-de-telepresence.md
@@ -1,0 +1,7 @@
+---
+area: Domaine 4
+title: Les systèmes robotisés de téléprésence
+description: Les systèmes robotisés de téléprésence permettent aux élèves empêchés de se rendre à l'école sur une longue période de suivre les cours et garder des liens avec ses camarades. Une vidéo pour en savoir plus.
+videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/4954a3c4-804d-4346-90b0-024a18d07674
+videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/4954a3c4-804d-4346-90b0-024a18d07674-1080-fragmented.mp4
+---

--- a/content/edu/les-travaux-academiques-mutualises.json
+++ b/content/edu/les-travaux-academiques-mutualises.json
@@ -1,9 +1,0 @@
-{
-  "area" : "Domaine 1",
-  "title": "Les Travaux académiques mutualisés (TraAM)",
-  "description": "Avez-vous déjà entendu parlé des TraAM ? Ces travaux inter-académiques menés par des enseignants du premier et du second degré abordent des thèmes émergents du numérique éducatif et proposent des scénarios pédagogiques associés. Plus de détails dans cette vidéo !",
-  "videoEmbedSrc": "https://tube.reseau-canope.fr/videos/embed/e2cc7464-70ab-4f8c-a069-5112c2896477",
-  "videoDLHref": "https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/e2cc7464-70ab-4f8c-a069-5112c2896477-1080-fragmented.mp4",
-  "fichePdfHref": "",
-  "transcriptPdfHref": ""
-}

--- a/content/edu/les-travaux-academiques-mutualises.md
+++ b/content/edu/les-travaux-academiques-mutualises.md
@@ -1,0 +1,7 @@
+---
+area: Domaine 1
+title: Les Travaux académiques mutualisés (TraAM)
+description: Avez-vous déjà entendu parlé des TraAM ? Ces travaux inter-académiques menés par des enseignants du premier et du second degré abordent des thèmes émergents du numérique éducatif et proposent des scénarios pédagogiques associés. Plus de détails dans cette vidéo !
+videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/e2cc7464-70ab-4f8c-a069-5112c2896477
+videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/e2cc7464-70ab-4f8c-a069-5112c2896477-1080-fragmented.mp4
+---

--- a/content/edu/methodes-et-outils-pour-concevoir-une-capsule-video.json
+++ b/content/edu/methodes-et-outils-pour-concevoir-une-capsule-video.json
@@ -1,9 +1,0 @@
-{
-  "area" : "Domaine 3",
-  "title": "Méthodes et outils pour concevoir une capsule vidéo",
-  "description": "Il existe de nombreuses manières de créer une capsule vidéo. Si vous hésitez encore, cette vidéo vous éclairera sûrement !",
-  "videoEmbedSrc": "https://tube.reseau-canope.fr/videos/embed/cb5b4cc7-63df-4cfc-9b81-3dd8c92e2e90",
-  "videoDLHref": "https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/cb5b4cc7-63df-4cfc-9b81-3dd8c92e2e90-1080-fragmented.mp4",
-  "fichePdfHref": "",
-  "transcriptPdfHref": ""
-}

--- a/content/edu/methodes-et-outils-pour-concevoir-une-capsule-video.md
+++ b/content/edu/methodes-et-outils-pour-concevoir-une-capsule-video.md
@@ -1,0 +1,7 @@
+---
+area: Domaine 3
+title: Méthodes et outils pour concevoir une capsule vidéo
+description: Il existe de nombreuses manières de créer une capsule vidéo. Si vous hésitez encore, cette vidéo vous éclairera sûrement !
+videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/cb5b4cc7-63df-4cfc-9b81-3dd8c92e2e90
+videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/cb5b4cc7-63df-4cfc-9b81-3dd8c92e2e90-1080-fragmented.mp4
+---

--- a/content/edu/methodes-et-outils-pour-le-montage-d-une-capsule-video.json
+++ b/content/edu/methodes-et-outils-pour-le-montage-d-une-capsule-video.json
@@ -1,9 +1,0 @@
-{
-  "area" : "Domaine 3",
-  "title": "Méthodes et outils pour le montage d'une capsule vidéo",
-  "description": "Pour supprimmer un temps mort ou un bruit parasite survenu lors de votre captation vidéo, le montage sera votre allié ! Plus d'informations dans cette vidéo.",
-  "videoEmbedSrc": "https://tube.reseau-canope.fr/videos/embed/992760ea-c778-4f45-b7fe-ff427c2c49db",
-  "videoDLHref": "https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/992760ea-c778-4f45-b7fe-ff427c2c49db-1080-fragmented.mp4",
-  "fichePdfHref": "",
-  "transcriptPdfHref": ""
-}

--- a/content/edu/methodes-et-outils-pour-le-montage-d-une-capsule-video.md
+++ b/content/edu/methodes-et-outils-pour-le-montage-d-une-capsule-video.md
@@ -1,0 +1,7 @@
+---
+area: Domaine 3
+title: Méthodes et outils pour le montage d'une capsule vidéo
+description: Pour supprimmer un temps mort ou un bruit parasite survenu lors de votre captation vidéo, le montage sera votre allié ! Plus d'informations dans cette vidéo
+videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/992760ea-c778-4f45-b7fe-ff427c2c49db
+videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/992760ea-c778-4f45-b7fe-ff427c2c49db-1080-fragmented.mp4
+---

--- a/content/edu/mettre-en-place-une-strategie-de-veille.json
+++ b/content/edu/mettre-en-place-une-strategie-de-veille.json
@@ -1,9 +1,0 @@
-{
-  "area" : "Domaine 1",
-  "title": "Mettre en place une stratégie de veille",
-  "description": "",
-  "videoEmbedSrc": "https://tube.reseau-canope.fr/videos/embed/c6d0bc8a-be09-4e15-a2f5-6aff8c3780ce",
-  "videoDLHref": "https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/c6d0bc8a-be09-4e15-a2f5-6aff8c3780ce-1080-fragmented.mp4",
-  "fichePdfHref": "",
-  "transcriptPdfHref": ""
-}

--- a/content/edu/mettre-en-place-une-strategie-de-veille.md
+++ b/content/edu/mettre-en-place-une-strategie-de-veille.md
@@ -1,0 +1,7 @@
+---
+area: Domaine 1
+title: Mettre en place une stratégie de veille
+description:
+videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/c6d0bc8a-be09-4e15-a2f5-6aff8c3780ce
+videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/c6d0bc8a-be09-4e15-a2f5-6aff8c3780ce-1080-fragmented.mp4
+---

--- a/content/edu/outils-pour-rendre-un-document-accessible.json
+++ b/content/edu/outils-pour-rendre-un-document-accessible.json
@@ -1,9 +1,0 @@
-{
-  "area" : "Domaine 4",
-  "title": "Outils pour rendre un document accessible",
-  "description": "Certains outils existent pour faciliter la création de supports pédagogiques numérique qui sont accessibles et adaptés aux différents besoins des élèves. Des détails dans cette vidéo !",
-  "videoEmbedSrc": "https://tube.reseau-canope.fr/videos/embed/71d601ca-6f19-4f7b-8904-dc074e4bfb7f",
-  "videoDLHref": "https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/71d601ca-6f19-4f7b-8904-dc074e4bfb7f-1080-fragmented.mp4",
-  "fichePdfHref": "",
-  "transcriptPdfHref": ""
-}

--- a/content/edu/outils-pour-rendre-un-document-accessible.md
+++ b/content/edu/outils-pour-rendre-un-document-accessible.md
@@ -1,0 +1,7 @@
+---
+area: Domaine 4
+title: Outils pour rendre un document accessible
+description: Certains outils existent pour faciliter la création de supports pédagogiques numérique qui sont accessibles et adaptés aux différents besoins des élèves. Des détails dans cette vidéo !
+videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/71d601ca-6f19-4f7b-8904-dc074e4bfb7f
+videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/71d601ca-6f19-4f7b-8904-dc074e4bfb7f-1080-fragmented.mp4
+---

--- a/content/edu/partager-et-diffuser-sa-veille-informationnelle.json
+++ b/content/edu/partager-et-diffuser-sa-veille-informationnelle.json
@@ -1,9 +1,0 @@
-{
-  "area" : "Domaine 1",
-  "title": "Partager et diffuser sa veille informationnelle",
-  "description": "Une fois que l'on a structuré sa veille informationnelle, on peut avoir envie de la partager à ses collègues et de la diffuser à des membres de la communauté éducative. Par où commencer ? Réponse dans cette vidéo.",
-  "videoEmbedSrc": "https://tube.reseau-canope.fr/videos/embed/be916f45-3257-477f-a060-10fb46564e83",
-  "videoDLHref": "https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/be916f45-3257-477f-a060-10fb46564e83-1080-fragmented.mp4",
-  "fichePdfHref": "",
-  "transcriptPdfHref": ""
-}

--- a/content/edu/partager-et-diffuser-sa-veille-informationnelle.md
+++ b/content/edu/partager-et-diffuser-sa-veille-informationnelle.md
@@ -1,0 +1,7 @@
+---
+area: Domaine 1
+title: Partager et diffuser sa veille informationnelle
+description: Une fois que l'on a structuré sa veille informationnelle, on peut avoir envie de la partager à ses collègues et de la diffuser à des membres de la communauté éducative. Par où commencer ? Réponse dans cette vidéo.
+videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/be916f45-3257-477f-a060-10fb46564e83
+videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/be916f45-3257-477f-a060-10fb46564e83-1080-fragmented.mp4
+---

--- a/content/edu/reperer-une-copie-ayant-eu-recours-au-plagiat.json
+++ b/content/edu/reperer-une-copie-ayant-eu-recours-au-plagiat.json
@@ -1,9 +1,0 @@
-{
-  "area" : "Domaine 3",
-  "title": "Repérer une copie ayant eu recours au plagiat",
-  "description": "Un doute sur l'authenticité d'un travail rendu sous un format numérique ? Dans cette vidéo, quelques solutions pour estimer rapidement si un élève est auteur de plagiat et des pistes pour sensibiliser ses élèves à ce sujet !",
-  "videoEmbedSrc": "https://tube.reseau-canope.fr/videos/embed/4d4ee6cd-cc4d-4253-9269-979a89835099",
-  "videoDLHref": "https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/4d4ee6cd-cc4d-4253-9269-979a89835099-1080-fragmented.mp4",
-  "fichePdfHref": "",
-  "transcriptPdfHref": ""
-}

--- a/content/edu/reperer-une-copie-ayant-eu-recours-au-plagiat.md
+++ b/content/edu/reperer-une-copie-ayant-eu-recours-au-plagiat.md
@@ -1,0 +1,7 @@
+---
+area: Domaine 3
+title: Repérer une copie ayant eu recours au plagiat
+description: Un doute sur l'authenticité d'un travail rendu sous un format numérique ? Dans cette vidéo, quelques solutions pour estimer rapidement si un élève est auteur de plagiat et des pistes pour sensibiliser ses élèves à ce sujet !
+videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/4d4ee6cd-cc4d-4253-9269-979a89835099
+videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/4d4ee6cd-cc4d-4253-9269-979a89835099-1080-fragmented.mp4
+---

--- a/content/edu/resoudre-des-problemes-simples-lies-aux-outils-numeriques.json
+++ b/content/edu/resoudre-des-problemes-simples-lies-aux-outils-numeriques.json
@@ -1,9 +1,0 @@
-{
-  "area" : "Domaine 5",
-  "title": "Résoudre des problèmes simples liés aux outils numériques",
-  "description": "En classe, on n'est malheuresement jamais à l'abri d'un pépin technique quand on utilise des outils numériques. Dans cette vidéo, vous trouverez des conseils pour les éviter et réagir en cas d'imprévu !",
-  "videoEmbedSrc": "https://tube.reseau-canope.fr/videos/embed/4d5da479-0fe2-4e63-befd-ad3082fed30f",
-  "videoDLHref": "https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/4d5da479-0fe2-4e63-befd-ad3082fed30f-1080-fragmented.mp4",
-  "fichePdfHref": "",
-  "transcriptPdfHref": ""
-}

--- a/content/edu/resoudre-des-problemes-simples-lies-aux-outils-numeriques.md
+++ b/content/edu/resoudre-des-problemes-simples-lies-aux-outils-numeriques.md
@@ -1,0 +1,7 @@
+---
+area: Domaine 5
+title: Résoudre des problèmes simples liés aux outils numériques
+description: En classe, on n'est malheuresement jamais à l'abri d'un pépin technique quand on utilise des outils numériques. Dans cette vidéo, vous trouverez des conseils pour les éviter et réagir en cas d'imprévu !
+videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/4d5da479-0fe2-4e63-befd-ad3082fed30f
+videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/4d5da479-0fe2-4e63-befd-ad3082fed30f-1080-fragmented.mp4
+---

--- a/content/edu/savoir-indexer-une-ressource-en-ligne-pour-la-partager.json
+++ b/content/edu/savoir-indexer-une-ressource-en-ligne-pour-la-partager.json
@@ -1,9 +1,0 @@
-{
-  "area" : "Domaine 2",
-  "title": "Savoir indexer une ressource en ligne pour la partager",
-  "description": "Une étape indispensable pour permettre à des collègues de trouver une ressource pédagogique géniale que l'on a partagée en ligne : l'indexation ! Toutes les explications dans cette vidéo.",
-  "videoEmbedSrc": "https://tube.reseau-canope.fr/videos/embed/3ad05af3-1ed3-4db7-8944-ff1286ed0d68",
-  "videoDLHref": "https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/3ad05af3-1ed3-4db7-8944-ff1286ed0d68-1080-fragmented.mp4",
-  "fichePdfHref": "",
-  "transcriptPdfHref": ""
-}

--- a/content/edu/savoir-indexer-une-ressource-en-ligne-pour-la-partager.md
+++ b/content/edu/savoir-indexer-une-ressource-en-ligne-pour-la-partager.md
@@ -1,0 +1,7 @@
+---
+area: Domaine 2
+title: Savoir indexer une ressource en ligne pour la partager
+description: "Une étape indispensable pour permettre à des collègues de trouver une ressource pédagogique géniale que l'on a partagée en ligne : l'indexation ! Toutes les explications dans cette vidéo."
+videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/3ad05af3-1ed3-4db7-8944-ff1286ed0d68
+videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/3ad05af3-1ed3-4db7-8944-ff1286ed0d68-1080-fragmented.mp4
+---

--- a/content/edu/scenariser-une-capsule-video.json
+++ b/content/edu/scenariser-une-capsule-video.json
@@ -1,9 +1,0 @@
-{
-  "area" : "Domaine 3",
-  "title": "Scénariser une capsule vidéo",
-  "description": "Avant de se lancer dans la captation vidéo, l'étape de scénarisation peut s'avérer précieuse pour créer une capsule dynamique et synthétique. ",
-  "videoEmbedSrc": "https://tube.reseau-canope.fr/videos/embed/e4c4a8af-4f7d-42db-ac6e-cc1ab09714e5",
-  "videoDLHref": "https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/e4c4a8af-4f7d-42db-ac6e-cc1ab09714e5-1080-fragmented.mp4",
-  "fichePdfHref": "",
-  "transcriptPdfHref": ""
-}

--- a/content/edu/scenariser-une-capsule-video.md
+++ b/content/edu/scenariser-une-capsule-video.md
@@ -1,0 +1,7 @@
+---
+area: Domaine 3
+title: Scénariser une capsule vidéo
+description: Avant de se lancer dans la captation vidéo, l'étape de scénarisation peut s'avérer précieuse pour créer une capsule dynamique et synthétique.
+videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/e4c4a8af-4f7d-42db-ac6e-cc1ab09714e5
+videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/e4c4a8af-4f7d-42db-ac6e-cc1ab09714e5-1080-fragmented.mp4
+---

--- a/content/edu/se-connecter-a-sa-messagerie-academique.json
+++ b/content/edu/se-connecter-a-sa-messagerie-academique.json
@@ -1,7 +1,0 @@
-{
-  "area" : "Domaine 1",
-  "title": "Se connecter à sa messagerie académique",
-  "description": "Avec cette vidéo, votre messagerie académique n'aura (quasiment) plus de secret pour vous !",
-  "videoEmbedSrc": "https://tube.reseau-canope.fr/videos/embed/09090670-0b40-478d-86b7-383451e602e8",
-  "videoDLHref": "https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/09090670-0b40-478d-86b7-383451e602e8-1080-fragmented.mp4"
-}

--- a/content/edu/se-connecter-a-sa-messagerie-academique.md
+++ b/content/edu/se-connecter-a-sa-messagerie-academique.md
@@ -1,0 +1,92 @@
+---
+area: Domaine 1
+title: Se connecter à sa messagerie académique
+description: Avec cette vidéo, votre messagerie académique n'aura (quasiment) plus de secret pour vous !
+videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/09090670-0b40-478d-86b7-383451e602e8
+videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/09090670-0b40-478d-86b7-383451e602e8-1080-fragmented.mp4
+---
+
+## Script
+
+Beaucoup d’informations passent aujourd’hui par votre messagerie académique, c’est
+pourquoi il est nécessaire de la consulter régulièrement.
+
+Pour communiquer en dehors de votre établissement, notamment vers votre hiérarchie,
+c'est le canal qu'il faut privilégier.
+
+Votre messagerie académique contient tous vos messages importants : lettres de rentrée,
+lettres de diffusion, notifications sur les mouvements et la gestion de carrière...
+
+Mais d'abord, comment accède-t-on à sa messagerie? Avec quel identifiant et quel mot de
+passe? Voici les explications pour faire vos premiers pas avec votre adresse académique.
+
+Toutes les adresses mails académiques se présentent sous la forme prénom.nom@ac-
+académie.fr.
+
+Exemple pour Michel Dupond dans l’académie de Lille : michel.dupond@ac-lille.fr.
+
+En cas d’homonymie, de prénoms composés ou de noms d’usage différents, il peut exister
+des exceptions.
+
+Si vous avez un doute sur votre adresse, n’hésitez pas à contacter la plateforme d'assistance
+informatique de votre académie.
+
+L’adresse internet des webmails académiques est généralement sous le format :
+https://webmail.ac-(nom de l’académie).fr.
+
+Pour trouver l’url de chaque académie, on peut passer par la page du site du Ministère ou
+effectuer une simple recherche sur Internet, « webmail académie de Lille » par exemple.
+
+L’interface ressemble à celle d’une messagerie classique.
+
+Comme pour toute messagerie, un identifiant et un mot de passe sont demandés pour se
+connecter.
+
+L’identifiant est en général composé de la manière suivante : première lettre du prénom
+suivie du nom. Exemple pour Michel Dupond : mdupond.
+
+
+Si plusieurs personnes correspondent à cet identifiant (Marie Dupond, Martin Dupond...), un
+chiffre est ajouté à la fin.
+
+Votre mot de passe par défaut est votre NUMEN, il est recommandé de le changer. Une fois
+connecté, cliquez dans le menu Options/Modifier le mot de passe.
+
+Attention à bien choisir ce mot de passe.
+
+D’après les recommandations de la CNIL, un bon mot de passe doit contenir au moins 12
+caractères et 4 types différents : des minuscules, des majuscules, des chiffres et des
+caractères spéciaux.
+
+Le mieux est d'utiliser un générateur de mot de passe : vous en trouverez sur le web.
+
+Un bon mot de passe est souvent difficile à retenir... Vous l’avez perdu? Pas de panique!
+
+Pas la peine de retourner toute la maison sens dessus-dessous...
+
+Si jamais cela vous arrive, rendez-vous simplement sur le webmail de votre académie, par
+exemple l’académie de Lille, vous pouvez alors utiliser la procédure d’auto-dépannage mise
+en place ou vous pouvez contacter la plateforme d'assistance informatique.
+
+Vos adresse et nom d'utilisateur vous seront redonnés et votre mot de passe réinitialisé (ce
+sera à nouveau votre NUMEN).
+
+Si vous avez perdu votre NUMEN, votre seul espoir est la DSDEN ou le secrétariat de votre
+établissement pour le second degré.
+
+Sachez également que vous pouvez utiliser votre mail académique sans passer par le
+webmail ou l’application du rectorat.
+
+Des logiciels spécialisés, appelés clients de messagerie, permettent de regrouper vos
+différents comptes, qu’ils soient professionnels ou privés, et de communiquer avec votre
+adresse mail privée ou votre adresse académique selon les circonstances.
+
+Ça y est, vous voici maintenant une pro de la messagerie pro!
+
+## Crédits
+
+- **Scénario** : Nicolas Sedel, Corentine Gasquet, Nicolas Braun, Sylvain Chagnard
+- **Direction de publication** : Marie-Caroline Missir
+- **Production** : Réseau Canopé
+- **Partenariat** : Pix
+Ressource produite avec le soutien du ministère de l’Éducation nationale et de la Jeunesse

--- a/content/edu/sites-ressources-pour-l-ecole-inclusive.json
+++ b/content/edu/sites-ressources-pour-l-ecole-inclusive.json
@@ -1,9 +1,0 @@
-{
-  "area" : "Domaine 4",
-  "title": "Sites ressources pour l'École inclusive",
-  "description": "Pour prendre en compte les besoins particuliers ou les handicaps de ses élèves, il existe certains sites de référence qui peuvent aider les enseignants à mieux les comprendre et les accompagner.",
-  "videoEmbedSrc": "https://tube.reseau-canope.fr/videos/embed/2e8aadf8-45d5-4b1b-b8f6-b232f8fb3792",
-  "videoDLHref": "https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/2e8aadf8-45d5-4b1b-b8f6-b232f8fb3792-1080-fragmented.mp4",
-  "fichePdfHref": "",
-  "transcriptPdfHref": ""
-}

--- a/content/edu/sites-ressources-pour-l-ecole-inclusive.md
+++ b/content/edu/sites-ressources-pour-l-ecole-inclusive.md
@@ -1,0 +1,7 @@
+---
+area: Domaine 4
+title: Sites ressources pour l'École inclusive
+description: Pour prendre en compte les besoins particuliers ou les handicaps de ses élèves, il existe certains sites de référence qui peuvent aider les enseignants à mieux les comprendre et les accompagner.
+videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/2e8aadf8-45d5-4b1b-b8f6-b232f8fb3792
+videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/2e8aadf8-45d5-4b1b-b8f6-b232f8fb3792-1080-fragmented.mp4
+---

--- a/content/edu/suivre-les-avancees-de-la-recherche-sur-le-numerique-educatif.json
+++ b/content/edu/suivre-les-avancees-de-la-recherche-sur-le-numerique-educatif.json
@@ -1,9 +1,0 @@
-{
-  "area" : "Domaine 1",
-  "title": "Suivre les avancées de la recherche sur le numérique éducatif",
-  "description": "De nombreux chercheurs en sciences de l'éducation s'intéressent à l'usage du numérique en pédagogie. Les résultats de ces recherches permettent d'interroger et de prendre du recul sur ces usages. Comment suivre en tant qu'enseignant les avancées des travaux de recherche à ce sujet ?",
-  "videoEmbedSrc": "https://tube.reseau-canope.fr/videos/embed/4b76c54c-4ea7-46f7-9643-2617f7ba8eb1",
-  "videoDLHref": "https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/4b76c54c-4ea7-46f7-9643-2617f7ba8eb1-1080-fragmented.mp4",
-  "fichePdfHref": "",
-  "transcriptPdfHref": ""
-}

--- a/content/edu/suivre-les-avancees-de-la-recherche-sur-le-numerique-educatif.md
+++ b/content/edu/suivre-les-avancees-de-la-recherche-sur-le-numerique-educatif.md
@@ -1,0 +1,7 @@
+---
+area: Domaine 1
+title: Suivre les avancées de la recherche sur le numérique éducatif
+description: De nombreux chercheurs en sciences de l'éducation s'intéressent à l'usage du numérique en pédagogie. Les résultats de ces recherches permettent d'interroger et de prendre du recul sur ces usages. Comment suivre en tant qu'enseignant les avancées des travaux de recherche à ce sujet ?
+videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/4b76c54c-4ea7-46f7-9643-2617f7ba8eb1
+videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/4b76c54c-4ea7-46f7-9643-2617f7ba8eb1-1080-fragmented.mp4
+---

--- a/content/edu/trouver-et-proposer-des-ressources-pour-le-site-prim-a-bord.json
+++ b/content/edu/trouver-et-proposer-des-ressources-pour-le-site-prim-a-bord.json
@@ -1,9 +1,0 @@
-{
-  "area" : "Domaine 2",
-  "title": "Trouver et proposer des ressources pour le site Prim à bord",
-  "description": "Si vous êtes enseignant du premier degré et que vous cherchez souvent des ressources pédagogiques sur internet, le site Prim à bord et cette vidéo explicative sont fait pour vous !",
-  "videoEmbedSrc": "https://tube.reseau-canope.fr/videos/embed/4c0e95cc-9e00-4193-af2f-7f7f341eceee",
-  "videoDLHref": "https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/4c0e95cc-9e00-4193-af2f-7f7f341eceee-1080-fragmented.mp4",
-  "fichePdfHref": "",
-  "transcriptPdfHref": ""
-}

--- a/content/edu/trouver-et-proposer-des-ressources-pour-le-site-prim-a-bord.md
+++ b/content/edu/trouver-et-proposer-des-ressources-pour-le-site-prim-a-bord.md
@@ -1,0 +1,7 @@
+---
+area: Domaine 2
+title: Trouver et proposer des ressources pour le site Prim à bord
+description: Si vous êtes enseignant du premier degré et que vous cherchez souvent des ressources pédagogiques sur internet, le site Prim à bord et cette vidéo explicative sont fait pour vous !
+videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/4c0e95cc-9e00-4193-af2f-7f7f341eceee
+videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/4c0e95cc-9e00-4193-af2f-7f7f341eceee-1080-fragmented.mp4
+---

--- a/content/edu/utiliser-des-capsules-video-en-classe.json
+++ b/content/edu/utiliser-des-capsules-video-en-classe.json
@@ -1,9 +1,0 @@
-{
-  "area" : "Domaine 3",
-  "title": "Utiliser des capsules vidéo en classe",
-  "description": "Les capsules vidéos peuvent être un moyen de varier le type de ressources pédagogiques proposées à ses élèves. Comment s'en saisir et les utiliser en classe ?",
-  "videoEmbedSrc": "https://tube.reseau-canope.fr/videos/embed/68d966e7-76f4-4ff2-8544-ab9a86c1b815",
-  "videoDLHref": "https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/68d966e7-76f4-4ff2-8544-ab9a86c1b815-1080-fragmented.mp4",
-  "fichePdfHref": "",
-  "transcriptPdfHref": ""
-}

--- a/content/edu/utiliser-des-capsules-video-en-classe.md
+++ b/content/edu/utiliser-des-capsules-video-en-classe.md
@@ -1,0 +1,7 @@
+---
+area: Domaine 3
+title: Utiliser des capsules vidéo en classe
+description: Les capsules vidéos peuvent être un moyen de varier le type de ressources pédagogiques proposées à ses élèves. Comment s'en saisir et les utiliser en classe ?
+videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/68d966e7-76f4-4ff2-8544-ab9a86c1b815
+videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/68d966e7-76f4-4ff2-8544-ab9a86c1b815-1080-fragmented.mp4
+---

--- a/content/edu/utiliser-les-outils-de-quiz-en-ligne-pour-diversifier-son-evaluation.json
+++ b/content/edu/utiliser-les-outils-de-quiz-en-ligne-pour-diversifier-son-evaluation.json
@@ -1,9 +1,0 @@
-{
-  "area" : "Domaine 3",
-  "title": "Utiliser les outils de quiz en ligne pour diversifier son évaluation",
-  "description": "Les quiz en ligne peuvent présenter certains avantages par rapport à des quiz débranchés : rétroaction, analyse synthétique de résultats, ... Plus de détails dans cette vidéo !",
-  "videoEmbedSrc": "https://tube.reseau-canope.fr/videos/embed/3a19ecea-b46e-479b-9bcc-7268b744534e",
-  "videoDLHref": "https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/3a19ecea-b46e-479b-9bcc-7268b744534e-1080-fragmented.mp4",
-  "fichePdfHref": "",
-  "transcriptPdfHref": ""
-}

--- a/content/edu/utiliser-les-outils-de-quiz-en-ligne-pour-diversifier-son-evaluation.md
+++ b/content/edu/utiliser-les-outils-de-quiz-en-ligne-pour-diversifier-son-evaluation.md
@@ -1,0 +1,7 @@
+---
+area: Domaine 3
+title: Utiliser les outils de quiz en ligne pour diversifier son évaluation
+description: 'Les quiz en ligne peuvent présenter certains avantages par rapport à des quiz débranchés : rétroaction, analyse synthétique de résultats, ... Plus de détails dans cette vidéo !'
+videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/3a19ecea-b46e-479b-9bcc-7268b744534e
+videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/3a19ecea-b46e-479b-9bcc-7268b744534e-1080-fragmented.mp4
+---

--- a/content/edu/utiliser-les-reseaux-sociaux-comme-outils-de-veille-informationnelle.json
+++ b/content/edu/utiliser-les-reseaux-sociaux-comme-outils-de-veille-informationnelle.json
@@ -1,9 +1,0 @@
-{
-  "area" : "Domaine 1",
-  "title": "Utiliser les réseaux sociaux comme outils de veille informationnelle",
-  "description": "Dans cette vidéo, quelques pistes pour outiller sa veille à l'aide des réseaux sociaux.",
-  "videoEmbedSrc": "https://tube.reseau-canope.fr/videos/embed/a7145305-857e-4973-a738-c3a582b3cdf1",
-  "videoDLHref": "https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/a7145305-857e-4973-a738-c3a582b3cdf1-1080-fragmented.mp4",
-  "fichePdfHref": "",
-  "transcriptPdfHref": ""
-}

--- a/content/edu/utiliser-les-reseaux-sociaux-comme-outils-de-veille-informationnelle.md
+++ b/content/edu/utiliser-les-reseaux-sociaux-comme-outils-de-veille-informationnelle.md
@@ -1,0 +1,7 @@
+---
+area: Domaine 1
+title: Utiliser les réseaux sociaux comme outils de veille informationnelle
+description: Dans cette vidéo, quelques pistes pour outiller sa veille à l'aide des réseaux sociaux.
+videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/a7145305-857e-4973-a738-c3a582b3cdf1
+videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/a7145305-857e-4973-a738-c3a582b3cdf1-1080-fragmented.mp4
+---

--- a/content/edu/utiliser-un-tni.json
+++ b/content/edu/utiliser-un-tni.json
@@ -1,9 +1,0 @@
-{
-  "area" : "Domaine 3",
-  "title": "Utiliser un TBI/TNI",
-  "description": "Au programme de cette vidéo : explication sur le fonctionnement d'un tableau numérique interactif et quelques exemples de fonctionnalités.",
-  "videoEmbedSrc": "https://tube.reseau-canope.fr/videos/embed/a948661e-2ee2-4250-9ee9-04dfde2d8753",
-  "videoDLHref": "https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/a948661e-2ee2-4250-9ee9-04dfde2d8753-1080-fragmented.mp4",
-  "fichePdfHref": "",
-  "transcriptPdfHref": ""
-}

--- a/content/edu/utiliser-un-tni.md
+++ b/content/edu/utiliser-un-tni.md
@@ -1,0 +1,7 @@
+---
+area: Domaine 3
+title: Utiliser un TBI/TNI
+description: "Au programme de cette vidéo : explication sur le fonctionnement d'un tableau numérique interactif et quelques exemples de fonctionnalités."
+videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/a948661e-2ee2-4250-9ee9-04dfde2d8753
+videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/a948661e-2ee2-4250-9ee9-04dfde2d8753-1080-fragmented.mp4
+---

--- a/content/edu/utiliser-une-illustration-en-licence-libre.json
+++ b/content/edu/utiliser-une-illustration-en-licence-libre.json
@@ -1,9 +1,0 @@
-{
-  "area" : "Domaine 2",
-  "title": "Utiliser une illustration en licence libre",
-  "description": "Peut-on utiliser librement n'importe quelle illustration pour ses supports de cours ? Qu’est-ce qu’une illustration en licence libre et pourquoi privilégier leur utilisation ? Éléments de réponse dans cette vidéo !",
-  "videoEmbedSrc": "https://tube.reseau-canope.fr/videos/embed/3a09576d-cf6c-4d3d-a920-e7f537f1a9ff",
-  "videoDLHref": "https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/3a09576d-cf6c-4d3d-a920-e7f537f1a9ff-1080-fragmented.mp4",
-  "fichePdfHref": "",
-  "transcriptPdfHref": ""
-}

--- a/content/edu/utiliser-une-illustration-en-licence-libre.md
+++ b/content/edu/utiliser-une-illustration-en-licence-libre.md
@@ -1,0 +1,7 @@
+---
+area: Domaine 2
+title: Utiliser une illustration en licence libre
+description: Peut-on utiliser librement n'importe quelle illustration pour ses supports de cours ? Qu’est-ce qu’une illustration en licence libre et pourquoi privilégier leur utilisation ? Éléments de réponse dans cette vidéo !
+videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/3a09576d-cf6c-4d3d-a920-e7f537f1a9ff
+videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/3a09576d-cf6c-4d3d-a920-e7f537f1a9ff-1080-fragmented.mp4
+---

--- a/pages/edu/_slug.vue
+++ b/pages/edu/_slug.vue
@@ -1,6 +1,7 @@
 <template>
   <article>
     <PixTutorial
+      :page="page"
       :title="page.title"
       :description="page.description"
       :video-embed-src="videoEmbedSrc"

--- a/services/parse-markdown.js
+++ b/services/parse-markdown.js
@@ -1,0 +1,27 @@
+/* Source : https://ilikekillnerds.com/2023/01/parsing-metadata-inside-of-markdown-using-javascript-without-any-dependencies/ */
+
+export default function parseMarkdownMetadata(markdown) {
+  // Regular expression to match metadata at the beginning of the file
+  const metadataRegex = /^---([\s\S]*?)---/;
+  const metadataMatch = markdown.match(metadataRegex);
+
+  // If there is no metadata, return an empty object
+  if (!metadataMatch) {
+    return {};
+  }
+
+  // Split the metadata into lines
+  const metadataLines = metadataMatch[1].split('\n');
+
+  // Use reduce to accumulate the metadata as an object
+  const metadata = metadataLines.reduce((acc, line) => {
+    // Split the line into key-value pairs
+    const [key, ...value] = line.split(':').map((part, value) => part.trim());
+    // If the line is not empty add the key-value pair to the metadata object
+    if (key) acc[key] = value.join(':');
+    return acc;
+  }, {});
+
+  // Return the metadata object
+  return metadata;
+}

--- a/tests/unit/services/parse-markdown.test.js
+++ b/tests/unit/services/parse-markdown.test.js
@@ -1,0 +1,36 @@
+import parseMarkdownMetadata from '../../../services/parse-markdown';
+
+describe('Unit | Services | Parse Markdown Metadata', function () {
+  describe('#parseMarkdownMetadata', function () {
+    it('should return an empty object if metadata doesnt exist', function () {
+      const markdown = `# My Blog Post
+      This is the content of my blog post.`;
+
+      const metadata = parseMarkdownMetadata(markdown);
+
+      expect(metadata).toStrictEqual({});
+    });
+
+    it('should parse metadata if exists', function () {
+      const markdown = `---
+      title: My Blog Post
+      author: John Doe
+      date: 2021-01-01
+      url: https://test.fr
+      ---
+      # My Blog Post
+      This is the content of my blog post.`;
+
+      const metadata = parseMarkdownMetadata(markdown);
+
+      const expectedResult = {
+        author: 'John Doe',
+        date: '2021-01-01',
+        title: 'My Blog Post',
+        url: 'https://test.fr',
+      };
+
+      expect(metadata).toStrictEqual(expectedResult);
+    });
+  });
+});

--- a/tests/unit/verify-edu-content.test.js
+++ b/tests/unit/verify-edu-content.test.js
@@ -1,42 +1,44 @@
 import path from 'path';
 import fs from 'fs';
 import getAreas from '../../services/get-areas';
+import parseMarkdownMetadata from '../../services/parse-markdown';
 
 describe('Verification du contenu dans le dossier `content/edu`', function () {
   const contentPath = path.join(__dirname, '../../content/edu');
   const dirContent = fs.readdirSync(contentPath);
 
   dirContent.forEach((file) => {
-    let tutoFileContent = {};
+    let tutoFileMetadata = {};
 
     beforeEach(function () {
       try {
-        tutoFileContent = require(path.join(contentPath, file));
+        const markdown = fs.readFileSync(path.join(contentPath, file), 'utf8');
+        tutoFileMetadata = parseMarkdownMetadata(markdown);
       } catch {
-        throw new Error(`Le fichier ${file} ne respecte pas le format JSON`);
+        throw new Error(`Le fichier ${file} n'a aucune metadonnée`);
       }
     });
 
     describe(`Le fichier ${file}`, function () {
-      it('doit avoir un nom alpha numérique et une extension en ".json"', () => {
+      it('doit avoir un nom alpha numérique et une extension en ".md"', () => {
         try {
-          expect(file).toMatch(/^[0-9a-z-_]+\.json$/);
+          expect(file).toMatch(/^[0-9a-z-_]+\.md$/);
         } catch {
           throw new Error(
-            `Le nom du fichier ${file} doit être en minuscule, ne pas contenir d'espace, d'accents ou de caractères spéciaux (sauf "-" et "_")`
+            `Le nom du fichier ${file} doit être en minuscule, finir par l'extension '.md', ne pas contenir d'espace, d'accents ou de caractères spéciaux (sauf "-" et "_")`
           );
         }
       });
 
       it('doit avoir un champ `area` existant', function () {
         try {
-          expect(tutoFileContent.area).toBeDefined();
-          expect(typeof tutoFileContent.area).toBe('string');
+          expect(tutoFileMetadata.area).toBeDefined();
+          expect(typeof tutoFileMetadata.area).toBe('string');
         } catch {
           throw new Error('Le champ "area" est obligatoire.');
         }
         try {
-          expect(getAreas()).toHaveProperty(tutoFileContent.area);
+          expect(getAreas()).toHaveProperty(tutoFileMetadata.area);
         } catch {
           throw new Error(
             `Cette valeur d'"area" n'est pas permise. Valeurs permises : ${Object.keys(
@@ -48,8 +50,8 @@ describe('Verification du contenu dans le dossier `content/edu`', function () {
 
       it('doit avoir un champ `title`', function () {
         try {
-          expect(tutoFileContent.title).toBeDefined();
-          expect(typeof tutoFileContent.title).toBe('string');
+          expect(tutoFileMetadata.title).toBeDefined();
+          expect(typeof tutoFileMetadata.title).toBe('string');
         } catch {
           throw new Error('Le champ "title" est obligatoire.');
         }
@@ -57,8 +59,8 @@ describe('Verification du contenu dans le dossier `content/edu`', function () {
 
       it('doit avoir un champ `description`', function () {
         try {
-          expect(tutoFileContent.description).toBeDefined();
-          expect(typeof tutoFileContent.description).toBe('string');
+          expect(tutoFileMetadata.description).toBeDefined();
+          expect(typeof tutoFileMetadata.description).toBe('string');
         } catch {
           throw new Error('Le champ "description" est obligatoire.');
         }
@@ -66,7 +68,7 @@ describe('Verification du contenu dans le dossier `content/edu`', function () {
 
       it('doit avoir un champ `videoEmbedSrc`', function () {
         try {
-          expect(tutoFileContent.videoEmbedSrc).toBeDefined();
+          expect(tutoFileMetadata.videoEmbedSrc).toBeDefined();
         } catch {
           throw new Error('Le champ "videoEmbedSrc" est obligatoire.');
         }
@@ -84,7 +86,7 @@ describe('Verification du contenu dans le dossier `content/edu`', function () {
         ];
         try {
           expect(acceptedFields).toEqual(
-            expect.arrayContaining(Object.keys(tutoFileContent))
+            expect.arrayContaining(Object.keys(tutoFileMetadata))
           );
         } catch {
           throw new Error(
@@ -95,53 +97,53 @@ describe('Verification du contenu dans le dossier `content/edu`', function () {
 
       it('le champ `videoEmbedSrc` doit avoir un format précis', function () {
         try {
-          expect(tutoFileContent.videoEmbedSrc).toMatch(
+          expect(tutoFileMetadata.videoEmbedSrc).toMatch(
             /^https:\/\/tube\.reseau-canope\.fr\/videos\/embed\/(\w|-)+$/
           );
         } catch {
           throw new Error(
             `Le format du lien "videoEmbedSrc" est invalide (format attendu : "https://tube.reseau-canope.fr/videos/embed/{ID_VIDEO}", valeur reçue : "${
-              tutoFileContent.videoEmbedSrc ?? ''
+              tutoFileMetadata.videoEmbedSrc ?? ''
             }")`
           );
         }
       });
 
       it('le champ `videoDLHref` doit avoir un format précis (si présent)', function () {
-        if (!tutoFileContent.videoDLHref) return;
+        if (!tutoFileMetadata.videoDLHref) return;
         try {
-          expect(tutoFileContent.videoDLHref).toMatch(
+          expect(tutoFileMetadata.videoDLHref).toMatch(
             /^https:\/\/tube\.reseau-canope\.fr\/download\/streaming-playlists\/hls\/videos\/(\w|-)+\.mp4$/
           );
         } catch {
           throw new Error(
-            `Le format du lien "videoDLHref" est invalide (format attendu : "https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/{ID_VIDEO}.mp4", valeur reçue : "${tutoFileContent.videoDLHref}")`
+            `Le format du lien "videoDLHref" est invalide (format attendu : "https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/{ID_VIDEO}.mp4", valeur reçue : "${tutoFileMetadata.videoDLHref}")`
           );
         }
       });
 
       it('le champ `fichePdfHref` doit avoir un format précis (si présent)', function () {
-        if (!tutoFileContent.fichePdfHref) return;
+        if (!tutoFileMetadata.fichePdfHref) return;
         try {
-          expect(tutoFileContent.fichePdfHref).toMatch(
+          expect(tutoFileMetadata.fichePdfHref).toMatch(
             /^https:\/\/dl\.pix\.fr\/tutoFileContents\/(\w|-)+\.pdf$/
           );
         } catch {
           throw new Error(
-            `Le format du lien "fichePdfHref" est invalide (format attendu : "https://dl.pix.fr/tutoFileContents/{ID_TUTOFileContent}.pdf", valeur reçue : "${tutoFileContent.fichePdfHref}")`
+            `Le format du lien "fichePdfHref" est invalide (format attendu : "https://dl.pix.fr/tutoFileContents/{ID_TUTOFileContent}.pdf", valeur reçue : "${tutoFileMetadata.fichePdfHref}")`
           );
         }
       });
 
       it('le champ `transcriptPdfHref` doit avoir un format précis (si présent)', function () {
-        if (!tutoFileContent.transcriptPdfHref) return;
+        if (!tutoFileMetadata.transcriptPdfHref) return;
         try {
-          expect(tutoFileContent.transcriptPdfHref).toMatch(
+          expect(tutoFileMetadata.transcriptPdfHref).toMatch(
             /^https:\/\/dl\.pix\.fr\/tutoFileContents\/(\w|-)+\.pdf$/
           );
         } catch {
           throw new Error(
-            `Le format du lien "transcriptPdfHref" est invalide (format attendu : "https://dl.pix.fr/tutoFileContents/{ID_TUTOFileContent}.pdf", valeur reçue : "${tutoFileContent.fichePdfHref}")`
+            `Le format du lien "transcriptPdfHref" est invalide (format attendu : "https://dl.pix.fr/tutoFileContents/{ID_TUTOFileContent}.pdf", valeur reçue : "${tutoFileMetadata.fichePdfHref}")`
           );
         }
       });


### PR DESCRIPTION
## :unicorn: Problème

Le site n'était pas vraiment accessible car on ne proposait pas de retranscription écrite des vidéos des tutos.

## :robot: Proposition

Ajouter une retranscription écrite en dessous des vidéos.

## :rainbow: Remarques

Pour ce faire, on remplace l'utilisation de fichiers JSON par des fichiers Markdown pour l'ajout de tutoriels.

Pour lire les metadonnées, un service JS a été ajouté.

## :100: Pour tester

Visiter la page du tuto "Agir face au cyberharcèlement" et constater l'affichage de la retranscription.
