### PR TITLE
[BUGFIX] Rétablir l'ordre des domaines (PIX-8149).

### DIFF
--- a/pages/edu/index.vue
+++ b/pages/edu/index.vue
@@ -73,7 +73,7 @@ export default {
   async setup() {
     useHead({ title: 'Accueil' });
 
-    const tutos = await queryContent('edu').sort('area').find();
+    const tutos = await queryContent('edu').sort({ area: 1, title: 1 }).find();
 
     const tutosGroupedByArea = tutos.reduce((acc, tuto) => {
       if (!acc[tuto.area]) {


### PR DESCRIPTION
## :unicorn: Problème
Les domaines ne sont pas affichés dans l'ordre alphabétique

## :robot: Proposition
Lors de la migration en Nuxt Content v2, nous n'avons pas respecté[ le nouveau format de tri](https://content.nuxtjs.org/api/composables/query-content/#sortoptions) 

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Se rendre sur /edu 
- Vérifier que les domaines sont affichés dans l'ordre alphabétique