### PR TITLE
[BUGFIX] Supprimer le lien d'ancrage des transcripts (PIX-8156)

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -35,4 +35,10 @@ export default defineNuxtConfig({
       },
     },
   },
+
+  content: {
+    markdown: {
+      anchorLinks: false,
+    },
+  },
 });


### PR DESCRIPTION
## :unicorn: Problème
Dans les transcripts, on se retrouve avec des liens d’ancres sur les titres du markdown. Ils portent à confusion, on souhaite que ce ne soit plus des liens. (L’`id` peut rester)

![image](https://github.com/1024pix/pix-tutos/assets/5855339/96df8576-b5c9-4b1e-8659-d158c3082c17)

## :robot: Proposition
Configurer Nuxt Content pour ne plus ajouter les liens dans les ancres.

## :rainbow: Remarques
RAS

## :100: Pour tester
Vérifier sur la RA que le premier tuto n'a pas de lien autour de l'ancre.
