### PR TITLE
[BUGFIX] Resserrer le bouton de téléchargement et le bloc vidéo (PIX-8155)

### DIFF
--- a/components/PixTutorial.vue
+++ b/components/PixTutorial.vue
@@ -119,7 +119,7 @@ export default {
     width: 100%;
     max-height: 95vmin;
     aspect-ratio: 16/9;
-    margin: 2rem 0;
+    margin: 2rem 0 1rem;
   }
 
   &__actions {
@@ -128,7 +128,7 @@ export default {
     list-style-type: none;
     gap: 1rem;
     padding: 0;
-    margin: 0;
+    margin: 0 0 2rem;
   }
 }
 


### PR DESCRIPTION
## :unicorn: Problème
L'espace entre le bouton "telechager" et la video et le text sont pas equilibres

## :robot: Proposition
Ajouter plus d'espace

## :rainbow: Remarques
RAS

## :100: Pour tester
Aller sur un tutoriel et verifier les espaces
