### PR TITLE
[BUGFIX] Utiliser les Design Tokens dans le rendu du transcript (PIX-8195)

### DIFF
--- a/assets/scss/_breakpoints.scss
+++ b/assets/scss/_breakpoints.scss
@@ -1,0 +1,16 @@
+$breakpoints: (
+  'mobile': (max-width: 768px),
+  'tablet': (min-width: 769px),
+  'desktop': (min-width: 992px),
+  'large-screen': (min-width: 1200px),
+) !default;
+
+@mixin device-is($breakpoint) {
+  @if map-has-key($breakpoints, $breakpoint) {
+    @media #{inspect(map-get($breakpoints, $breakpoint))} {
+      @content;
+    }
+  } @else {
+    @warn "Unfortunately, no value could be retrieved from `#{$breakpoint}`. Available breakpoints are: #{map-keys($breakpoints)}.";
+  }
+}

--- a/assets/scss/_design-tokens.scss
+++ b/assets/scss/_design-tokens.scss
@@ -2,8 +2,8 @@
 // @import './fonts/open-sans';
 // @import './fonts/roboto';
 
-$open-sans: 'Open Sans', Arial, sans-serif;
-$roboto: 'Roboto', Arial, sans-serif;
+$font-open-sans: 'Open Sans', Arial, sans-serif;
+$font-roboto: 'Roboto', Arial, sans-serif;
 
 $pix-neutral-90: #172b4d;
 $pix-neutral-70: #344563;

--- a/assets/scss/_typography.scss
+++ b/assets/scss/_typography.scss
@@ -1,0 +1,126 @@
+@import './design-tokens';
+@import './breakpoints';
+
+// Copie de https://github.com/1024pix/pix-ui/blob/dev/addon/styles/pix-design-tokens/_typography.scss
+
+// Placeholder pour permettre l'utilisation dans une classe css si jamais le tag html a trop de classe
+%-pix-title {
+  font-family: $font-open-sans;
+  font-weight: 500;
+}
+
+%pix-title-l,
+.pix-title-l {
+  @extend %-pix-title;
+
+  font-size: 2rem;
+  line-height: 1.25;
+  letter-spacing: -0.04em;
+
+  @include device-is('tablet') {
+    font-size: 2.5rem;
+  }
+
+  @include device-is('desktop') {
+    font-size: 3rem;
+  }
+}
+
+%pix-title-m,
+.pix-title-m {
+  @extend %-pix-title;
+
+  font-size: 1.625rem;
+  line-height: 1.3;
+  letter-spacing: -0.02em;
+
+  @include device-is('tablet') {
+    font-size: 2rem;
+    line-height: 1.25;
+    letter-spacing: -0.04em;
+  }
+
+  @include device-is('desktop') {
+    font-size: 2.25rem;
+  }
+}
+
+%pix-title-s,
+.pix-title-s {
+  @extend %-pix-title;
+
+  font-size: 1.375rem;
+  line-height: 1.3;
+  letter-spacing: -0.02em;
+
+  @include device-is('tablet') {
+    font-size: 1.5rem;
+  }
+
+  @include device-is('desktop') {
+    font-size: 1.75rem;
+  }
+}
+
+%pix-title-xs,
+.pix-title-xs {
+  @extend %-pix-title;
+
+  font-size: 1.25rem;
+  line-height: 1.4;
+  letter-spacing: -0.02em;
+}
+
+%-pix-body {
+  font-family: $font-roboto;
+  font-weight: 400;
+}
+
+%pix-body-l,
+.pix-body-l {
+  @extend %-pix-body;
+
+  font-size: 1rem;
+  line-height: 1.5;
+
+  @include device-is('tablet') {
+    font-size: 1.125rem;
+  }
+}
+
+%pix-body-m,
+.pix-body-m {
+  @extend %-pix-body;
+
+  font-size: 0.875rem;
+  line-height: 1.5;
+
+  @include device-is('tablet') {
+    font-size: 1rem;
+  }
+}
+
+%pix-body-s,
+.pix-body-s {
+  @extend %-pix-body;
+
+  font-size: 0.875rem;
+  line-height: 1.5;
+}
+
+%pix-body-xs,
+.pix-body-xs {
+  @extend %-pix-body;
+
+  font-size: 0.75rem;
+  line-height: 1.5;
+  letter-spacing: 0.02em;
+}
+
+.pix-body-weight-medium {
+  font-weight: 500;
+}
+
+.pix-body-weight-bold {
+  font-weight: 700;
+}

--- a/assets/scss/globals.scss
+++ b/assets/scss/globals.scss
@@ -1,0 +1,21 @@
+@import './typography';
+
+h1 {
+  @extend %pix-title-l;
+}
+
+h2 {
+  @extend %pix-title-m;
+}
+
+h3 {
+  @extend %pix-title-s;
+}
+
+h4 {
+  @extend %pix-title-xs;
+}
+
+p, li {
+  @extend %pix-body-m;
+}

--- a/components/PixButtonLink.vue
+++ b/components/PixButtonLink.vue
@@ -31,7 +31,7 @@ export default {
 .pix-button {
   display: block;
   text-decoration: none;
-  font-family: $roboto;
+  font-family: $font-roboto;
   font-size: 0.875rem;
   font-weight: 500;
   line-height: 1.25rem;

--- a/components/PixTypography.vue
+++ b/components/PixTypography.vue
@@ -41,7 +41,7 @@ export default {
 }
 
 .pix-typography--scale-title-large {
-  font-family: $open-sans;
+  font-family: $font-open-sans;
   font-size: 2rem;
 
   @media (min-width: 768px) {
@@ -54,7 +54,7 @@ export default {
 }
 
 .pix-typography--scale-title-medium {
-  font-family: $open-sans;
+  font-family: $font-open-sans;
   font-size: 1.625rem;
   letter-spacing: -0.02em;
 
@@ -69,7 +69,7 @@ export default {
 }
 
 .pix-typography--scale-title-small {
-  font-family: $open-sans;
+  font-family: $font-open-sans;
   font-size: 1.375rem;
   letter-spacing: -0.02em;
 
@@ -83,14 +83,14 @@ export default {
 }
 
 .pix-typography--scale-title-extra-small {
-  font-family: $open-sans;
+  font-family: $font-open-sans;
   font-size: 1.25rem;
   letter-spacing: -0.02em;
 }
 
 // Bodys
 [class*='pix-typography--scale-body'] {
-  font-family: $roboto;
+  font-family: $font-roboto;
   line-height: 1.5;
 }
 

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -39,7 +39,7 @@ export default {
 <style lang="scss">
 #app {
   min-height: 100vh;
-  font-family: $open-sans;
+  font-family: $font-roboto;
   background-color: $background-light;
 }
 

--- a/layouts/edu.vue
+++ b/layouts/edu.vue
@@ -43,7 +43,7 @@ export default {
 <style lang="scss">
 #app {
   min-height: 100vh;
-  font-family: $open-sans;
+  font-family: $font-roboto;
   background-color: $background-light;
 }
 


### PR DESCRIPTION
## :unicorn: Problème
Le rendu du transcript de vidéos ne respecte pas les Design Tokens de typographie.

## :robot: Proposition
Styliser les typographies de `h1`, `h2`, `p` et `li` par défaut

## :rainbow: Remarques
Il faudra revoir le composant `PixTypography` pour simplifier les choses, peut être le supprimer ?

## :100: Pour tester
Vérifier qu'on applique du `pix-body-m` dans le contenu des transcripts et du `pix-title-m` sur les `h2`.
