### PR TITLE
[FEATURE] Ajouter un bouton de téléchargement du transcript (PIX-8151).

### DIFF
--- a/assets/scss/globals.scss
+++ b/assets/scss/globals.scss
@@ -19,3 +19,26 @@ h4 {
 p, li {
   @extend %pix-body-m;
 }
+
+// We cannot extend placeholders when using a media query.
+// We chose to copy typography styles manually.
+@media print {
+  h1 {
+    font-size: 1.375rem;
+    line-height: 1.3;
+    letter-spacing: -0.02em;
+  }
+
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.4;
+    letter-spacing: -0.02em;
+  }
+
+  p, li {
+    font-size: 0.75rem;
+    line-height: 1.5;
+    letter-spacing: 0.02em;
+    text-align: justify;
+  }
+}

--- a/components/PixButton.vue
+++ b/components/PixButton.vue
@@ -1,0 +1,74 @@
+<template>
+  <button
+    class="pix-button pix-button--border pix-button--shape-squircle pix-button--size-small"
+    :class="`pix-button--background-${backgroundColor}`"
+    :onClick="action"
+  >
+    <slot />
+  </button>
+</template>
+
+<script>
+export default {
+  name: 'PixButtonLink',
+  props: {
+    action: {
+      type: Function,
+      required: true,
+    },
+    backgroundColor: {
+      type: String,
+      default: 'blue',
+      validator(val) {
+        return ['blue', 'transparent-light'].includes(val);
+      },
+    },
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.pix-button {
+  display: block;
+  text-decoration: none;
+  font-family: $font-roboto;
+  font-size: 0.875rem;
+  font-weight: 500;
+  line-height: 1.25rem;
+  white-space: nowrap;
+
+  &--size-small {
+    padding: 0.5rem 1rem;
+  }
+
+  &--shape-squircle {
+    border-radius: 0.25rem;
+  }
+
+  &--border {
+    border: 2px solid transparent;
+  }
+
+  &--background-blue {
+    color: white;
+    background: $blue-50;
+
+    &:hover,
+    &:focus {
+      background: $blue-hover;
+      border-color: white;
+      box-shadow: 0 0 0 2px $blue-hover;
+    }
+  }
+
+  &--background-transparent-light {
+    color: $black-90;
+    background: transparent;
+    border-color: $black-50;
+
+    &:hover {
+      background-color: $hover-grey;
+    }
+  }
+}
+</style>

--- a/components/PixTutorial.vue
+++ b/components/PixTutorial.vue
@@ -54,6 +54,15 @@
           Télécharger la retranscription
         </PixButtonLink>
       </li>
+      <li
+        class="tuto-actions__item"
+      >
+        <PixButton
+          :action="downloadTranscript"
+        >
+          Télécharger la retranscription
+        </PixButton>
+      </li>
     </ul>
 
     <ContentDoc :value="page">
@@ -97,6 +106,11 @@ export default {
       default: null,
     },
   },
+  methods: {
+    downloadTranscript() {
+      window.print();
+    },
+  }
 };
 </script>
 

--- a/layouts/edu.vue
+++ b/layouts/edu.vue
@@ -29,4 +29,19 @@
   max-width: 980px;
   margin: 0 auto;
 }
+
+@media print {
+  #app {
+    background-color: $pix-neutral-0;
+  }
+
+  .main-container {
+    padding: 0;
+  }
+
+  // Nous mettons le !important pour éviter la surcharge du style par celui de la page qui est appliqué ensuite.
+  .main-header, .tuto__description, .tuto__video, .tuto__actions {
+    display: none !important;
+  }
+}
 </style>


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, il n'y a pas de bouton à disposition pour télécharger le pdf du transcript.

## :robot: Proposition
Styliser l'affichage du transcript pour l'impression et ajouter un bouton de téléchargement (bouton d'impression).

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Aller sur un tutoriel 
- Cliquer sur le bouton "Télécharger la retranscription"