### PR TITLE
[FEATURE] Ajoute les logos de partenaires en fin des pages Edu + renommer 'script'/'transcript' en 'transcription' (PIX-8256)

### DIFF
--- a/components/PixTutorial.vue
+++ b/components/PixTutorial.vue
@@ -60,7 +60,7 @@
         <PixButton
           :action="downloadTranscript"
         >
-          Télécharger la retranscription
+          Télécharger la transcription
         </PixButton>
       </li>
     </ul>

--- a/content/edu/agir-face-au-cyberharcelement.md
+++ b/content/edu/agir-face-au-cyberharcelement.md
@@ -6,7 +6,7 @@ videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/17831907-e7cb-439a-a5c
 videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/17831907-e7cb-439a-a5c8-2e0453c878e3-1080-fragmented.mp4
 ---
 
-## Script
+## Transcription
 
 Derrière son écran, on surfe d'un site à l’autre, on partage des photos avec ses amis, on
 échange sur des réseaux sociaux... Si le web est un formidable espace de communication,

--- a/content/edu/appliquer-l-exception-pedagogique-et-les-exceptions-aux-droits-d-auteur.md
+++ b/content/edu/appliquer-l-exception-pedagogique-et-les-exceptions-aux-droits-d-auteur.md
@@ -6,7 +6,7 @@ videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/4512d4a2-2f3f-42e0-895
 videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/4512d4a2-2f3f-42e0-8958-8e6ffbb6561e-1080-fragmented.mp4
 ---
 
-## Script
+## Transcription
 
 Appliquer l'exception pédagogique et les exceptions aux droits d'auteur
 

--- a/content/edu/cadre-et-acteurs-du-rgpd-en-milieu-scolaire.md
+++ b/content/edu/cadre-et-acteurs-du-rgpd-en-milieu-scolaire.md
@@ -6,7 +6,7 @@ videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/4d2fd5f5-adca-4ccb-920
 videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/4d2fd5f5-adca-4ccb-9208-a4796f68d038-1080-fragmented.mp4
 ---
 
-## Script
+## Transcription
 
 Martin est directeur d’école primaire. Il a repéré un outil numérique de communication entre l’école et les familles qui lui semble vraiment intéressant. Mais il s’interroge sur son droit à utiliser cet outil.
 Vers qui peut-il se tourner pour que le règlement général sur la protection des données

--- a/content/edu/communiquer-efficacement-par-differents-canaux-aupres-de-ses-eleves.md
+++ b/content/edu/communiquer-efficacement-par-differents-canaux-aupres-de-ses-eleves.md
@@ -6,7 +6,7 @@ videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/31ea90d9-6d86-49b1-b6e
 videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/31ea90d9-6d86-49b1-b6e1-4cc008000dbe-1080-fragmented.mp4
 ---
 
-## Script
+## Transcription
 
 Mail académique, messagerie ENT, cahier de textes en ligne, réseaux sociaux, blog, forum...
 on peut se sentir un peu perdu devant la multiplication des canaux de communication! Pour

--- a/content/edu/communiquer-par-voie-numerique-aupres-de-la-communaute-educative.md
+++ b/content/edu/communiquer-par-voie-numerique-aupres-de-la-communaute-educative.md
@@ -6,7 +6,7 @@ videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/ef3f3ced-c2ee-41c0-91c
 videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/ef3f3ced-c2ee-41c0-91c7-1b7ad83f0de5-1080-fragmented.mp4
 ---
 
-## Script
+## Transcription
 
 Messagerie de l’ENT, de Pronote, cahier de texte, webmail de l’académie, réseaux sociaux...
 Qu'il s'adresse à l'administration, à l'académie, à ses collègues, ses élèves ou même aux

--- a/content/edu/comprendre-comment-differencier-grace-au-numerique.md
+++ b/content/edu/comprendre-comment-differencier-grace-au-numerique.md
@@ -6,7 +6,7 @@ videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/9520b54d-0a3c-43dc-882
 videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/9520b54d-0a3c-43dc-8821-d559fa418cc6-1080-fragmented.mp4
 ---
 
-## Script
+## Transcription
 
 Pour Camille, professeur(e) des écoles, une classe idéale, c’est :
 – un objectif d’apprentissage commun ;

--- a/content/edu/comprendre-les-creative-commons-pour-une-utilisation-pedagogique.md
+++ b/content/edu/comprendre-les-creative-commons-pour-une-utilisation-pedagogique.md
@@ -6,7 +6,7 @@ videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/17d63f12-2a68-4110-894
 videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/17d63f12-2a68-4110-8943-dba74582befd-1080-fragmented.mp4
 ---
 
-## Script
+## Transcription
 
 Vous souhaitez mettre en place une webtv au sein de votre établissement ?
 Vous aimeriez que vos élèves enregistrent des journaux et que les émissions soient ensuite diffusées sur Internet ?

--- a/content/edu/configurer-son-client-de-messagerie-pour-recevoir-ses-mails-academiques.md
+++ b/content/edu/configurer-son-client-de-messagerie-pour-recevoir-ses-mails-academiques.md
@@ -6,7 +6,7 @@ videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/4009d7ec-c48a-4a13-819
 videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/4009d7ec-c48a-4a13-8198-7a083af3d61f-1080-fragmented.mp4
 ---
 
-## Script
+## Transcription
 
 Chaque enseignant a généralement plusieurs adresses mail : l’adresse académique et au
 moins une adresse personnelle.

--- a/content/edu/connaitre-des-applications-a-videoprojeter-pour-animer-et-gerer-sa-classe.md
+++ b/content/edu/connaitre-des-applications-a-videoprojeter-pour-animer-et-gerer-sa-classe.md
@@ -6,7 +6,7 @@ videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/b83d2ab8-e18f-4156-9ed
 videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/b83d2ab8-e18f-4156-9eda-8a49f8a59de9-1080-fragmented.mp4
 ---
 
-## Script
+## Transcription
 
 En classe, on peut avoir besoin d’outils divers pour, par exemple, chronométrer une activité, tirer au sort le nom d’un élève à interroger, déterminer des groupes de travail ou créer un nuage de mots. Il existe, parmi les ressources numériques en ligne, des outils permettant de disposer de multiples fonctionnalités dans un seul et même endroit.
 On appelle ce type d’outil « fond d’écran interactif » ou « tableau de bord modulable », et, parmi eux, certains ont été créés par des enseignants désireux de rendre leurs séquences plus claires et plus dynamiques pour les élèves. Ces logiciels sont d'ailleurs en constante évolution.

--- a/content/edu/connaitre-des-outils-de-quiz-en-ligne.md
+++ b/content/edu/connaitre-des-outils-de-quiz-en-ligne.md
@@ -6,7 +6,7 @@ videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/2fc37e8d-860d-4789-a09
 videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/2fc37e8d-860d-4789-a092-e6ca3b113943-1080-fragmented.mp4
 ---
 
-## Script
+## Transcription
 
 Comment savoir si les élèves ont bien compris une notion ? Le moyen le plus simple est de leur poser des questions !
 

--- a/content/edu/identifier-des-sources-de-veille-incontournables.md
+++ b/content/edu/identifier-des-sources-de-veille-incontournables.md
@@ -6,7 +6,7 @@ videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/b456fcdb-64d5-425e-8ff
 videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/b456fcdb-64d5-425e-8ff2-c023e9cb9543-1080-fragmented.mp4
 ---
 
-## Script
+## Transcription
 
 Réforme des programmes, nouvelles recherches en neurosciences, différenciation, inclusion... Il peut être déroutant et chronophage de chercher des informations sur tous ces sujets, pourtant essentiels. Et si l'information venait à vous ? Avec une bonne stratégie et des sources pertinentes, on peut rester informé sans y passer trop de temps. C'est ce que l'on appelle la veille informationnelle.
 

--- a/content/edu/la-classe-inversee.md
+++ b/content/edu/la-classe-inversee.md
@@ -6,7 +6,7 @@ videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/9d109c46-311c-49ce-826
 videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/9d109c46-311c-49ce-826e-406581233be0-1080-fragmented.mp4
 ---
 
-## Script
+## Transcription
 
 Favoriser l’attention des élèves et solliciter un engagement actif de leur part sont des défis qui se posent à l’enseignant à chaque séance. Le développement du numérique a amené de nouvelles pistes de réflexion pédagogique et permet de réinterroger certaines pratiques d'enseignement.
 La classe inversée est souvent présentée comme un moyen de responsabiliser les élèves, de les rendre actifs, tout en leur accordant une grande autonomie.

--- a/content/edu/le-cadre-de-reference-des-competences-numeriques.md
+++ b/content/edu/le-cadre-de-reference-des-competences-numeriques.md
@@ -6,7 +6,7 @@ videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/1d82b613-ee83-4b08-895
 videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/1d82b613-ee83-4b08-895d-61a10aa8ecdb-1080-fragmented.mp4
 ---
 
-## Script
+## Transcription
 
 Depuis son entrée en école élémentaire, Léa apprend à se servir du numérique en classe.
 De gestes basiques pour utiliser l’écran tactile d’une tablette en primaire à la création graphique au lycée, Léa développe une multitude de compétences numériques pendant sa scolarité. Et cela se poursuivra dans sa vie personnelle et professionnelle.

--- a/content/edu/le-cahier-de-texte-numerique.md
+++ b/content/edu/le-cahier-de-texte-numerique.md
@@ -6,7 +6,7 @@ videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/d797ea7c-77f3-45fc-b47
 videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/d797ea7c-77f3-45fc-b47a-823cb63745b9-1080-fragmented.mp4
 ---
 
-## Script
+## Transcription
 
 Jusqu’en 2010, la version papier du cahier de texte de la classe était omniprésente dans la vie des élèves. Tour à tour et en binôme, ils le faisaient passer aux enseignants pour que ceux-ci y renseignent le déroulement de leurs cours.
 Depuis, dans le second degré, il a été remplacé par le cahier de texte numérique, un outil vite devenu incontournable pour les élèves et pour les enseignants !

--- a/content/edu/le-cyberharcelement.md
+++ b/content/edu/le-cyberharcelement.md
@@ -6,7 +6,7 @@ videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/ef2ca374-d224-4440-960
 videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/ef2ca374-d224-4440-960c-69d335973a52-1080-fragmented.mp4
 ---
 
-## Script
+## Transcription
 
 Derrière son écran, on surfe d'un site à l’autre, on partage des photos avec ses amis, on échange sur des réseaux sociaux… Si le web est un formidable espace de communication, celle-ci n’est pas toujours bienveillante malheureusement.
 Qu’appelle-t-on cyberharcèlement ?

--- a/content/edu/le-droit-a-l-image-des-eleves.md
+++ b/content/edu/le-droit-a-l-image-des-eleves.md
@@ -6,7 +6,7 @@ videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/21e4730e-59f2-4363-bb8
 videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/21e4730e-59f2-4363-bb8f-7425e4031cc0-1080-fragmented.mp4
 ---
 
-## Script
+## Transcription
 
 Dans une année scolaire, les élèves vivent parfois des moments forts comme des voyages, des visites au musée ou des spectacles de fin d’année. Et c’est souvent l’enseignant qui a le rôle de photographe pour immortaliser ces instants !
 Mais se posent alors plusieurs questions :

--- a/content/edu/le-droit-d-auteur-des-eleves.md
+++ b/content/edu/le-droit-d-auteur-des-eleves.md
@@ -6,7 +6,7 @@ videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/ef12284a-5da4-478f-83f
 videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/ef12284a-5da4-478f-83fa-51db88b9ce9d-1080-fragmented.mp4
 ---
 
-## Script
+## Transcription
 
 Au cours d’une année scolaire, les élèves peuvent être amenés à réaliser des productions originales comme des dessins, des poèmes, des vidéos.
 Afin de valoriser ces réalisations, vous décidez de les exposer dans l’enceinte de l’établissement scolaire et pourquoi pas de les diffuser sur votre blog ou sur vos réseaux sociaux.

--- a/content/edu/le-modele-samr-pour-integrer-le-numerique-dans-la-pedagogie.md
+++ b/content/edu/le-modele-samr-pour-integrer-le-numerique-dans-la-pedagogie.md
@@ -6,7 +6,7 @@ videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/fb9ee01b-1d22-404d-849
 videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/fb9ee01b-1d22-404d-8496-d14c0c698796-1080-fragmented.mp4
 ---
 
-## Script
+## Transcription
 
 Pour explorer la mer, il existe de nombreuses approches permettant d’atteindre différents buts. Pour explorer le numérique en classe, c’est la même chose. Selon les objectifs pédagogiques, l’enseignant doit questionner les outils et les pratiques numériques qu’il peut intégrer.
 Le modèle SAMR peut aider les enseignants dans cette réflexion.

--- a/content/edu/le-modele-tpack-pour-integrer-le-numerique-dans-la-pedagogie.md
+++ b/content/edu/le-modele-tpack-pour-integrer-le-numerique-dans-la-pedagogie.md
@@ -6,7 +6,7 @@ videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/11823461-ed6a-4607-8b7
 videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/11823461-ed6a-4607-8b7a-e39ba906c481-1080-fragmented.mp4
 ---
 
-## Script
+## Transcription
 
 Pour choisir un usage approprié du numérique en fonction de l’enjeu pédagogique, on peut s'appuyer sur le modèle SAMR, présenté dans une précédente vidéo.
 En complément, il existe un autre modèle pour réfléchir à l'intégration du numérique dans ses cours : le modèle TPaCK.

--- a/content/edu/le-principe-de-l-exception-pedagogique.md
+++ b/content/edu/le-principe-de-l-exception-pedagogique.md
@@ -6,7 +6,7 @@ videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/48dcc19b-31fb-45a8-acb
 videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/48dcc19b-31fb-45a8-acb0-4304d24eaf22-1080-fragmented.mp4
 ---
 
-## Script
+## Transcription
 
 Pour faire passer une idée, le moyen le plus pertinent est parfois l’illustration. Et utiliser des œuvres célèbres peut donner plus de perspectives encore à vos propos. Mais qui dit œuvre dit auteur, et donc droit d’auteur.
 - Comment le respecter en classe ?

--- a/content/edu/le-rgpd-en-milieu-scolaire.md
+++ b/content/edu/le-rgpd-en-milieu-scolaire.md
@@ -6,7 +6,7 @@ videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/80dcdd6b-5c58-4846-994
 videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/80dcdd6b-5c58-4846-9943-1c0d8f6866b9-1080-fragmented.mp4
 ---
 
-## Script
+## Transcription
 
 Pour un projet autour de la mobilité au collège, une classe voudrait créer un sondage en ligne.
 Des informations sur les habitudes des élèves seront collectées.

--- a/content/edu/le-site-cap-ecole-inclusive.md
+++ b/content/edu/le-site-cap-ecole-inclusive.md
@@ -6,7 +6,7 @@ videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/b2b7cf75-69b2-40db-a35
 videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/b2b7cf75-69b2-40db-a35c-164457affaaa-1080-fragmented.mp4
 ---
 
-## Script
+## Transcription
 
 Lorsqu'on accueille dans sa classe un élève à besoins éducatifs particuliers, il existe des outils simples et des ressources validées par la recherche pour adapter son enseignement à tous.
 L’année scolaire commence, Mathieu est professeur d’histoire. Dans son cours il accueille Tristan, accompagné de Françoise, son AESH.

--- a/content/edu/learning-analytics-et-intelligence-artificielle-dans-l-education.md
+++ b/content/edu/learning-analytics-et-intelligence-artificielle-dans-l-education.md
@@ -6,7 +6,7 @@ videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/d66e9416-39ee-4d25-bac
 videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/d66e9416-39ee-4d25-bac8-80552dcc463b-1080-fragmented.mp4
 ---
 
-## Script
+## Transcription
 
 Avec le développement du numérique éducatif, les traces laissées par les élèves génèrent une masse de données considérable. Les Learning analytics – ou analyses des traces d’apprentissage – permettent de collecter, d’analyser et de communiquer ces données.
 On associe par ailleurs aux Learning analytics l’intelligence artificielle, que l’on peut définir comme un système autonome et adaptatif capable de comprendre, prévoir et prescrire les actions de l’élève grâce à l'analyse de grandes quantités de données.

--- a/content/edu/les-acteurs-de-la-formation-en-ligne-des-enseignants.md
+++ b/content/edu/les-acteurs-de-la-formation-en-ligne-des-enseignants.md
@@ -6,7 +6,7 @@ videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/67df24ff-e146-45ae-8ec
 videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/67df24ff-e146-45ae-8eca-562bce282d50-1080-fragmented.mp4
 ---
 
-## Script
+## Transcription
 
 Être enseignant demande de mettre à jour régulièrement ses connaissances didactiques et d’enrichir sa pédagogie.
 En plus des formations en présentiel, de nombreuses formations à distance sont aujourd’hui proposées par l’Éducation Nationale.

--- a/content/edu/les-acteurs-institutionnels-du-numerique-educatif-dans-le-2nd-degre.md
+++ b/content/edu/les-acteurs-institutionnels-du-numerique-educatif-dans-le-2nd-degre.md
@@ -6,7 +6,7 @@ videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/b2d55662-aae2-41f3-8fa
 videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/b2d55662-aae2-41f3-8fa0-2b0e6ad4de87-1080-fragmented.mp4
 ---
 
-## Script
+## Transcription
 
 RUPN, responsable d’affectation GAR, DANE ou DRANE, IAN... Ils sont nombreux à
 contribuer au développement du numérique éducatif. C’est parfois difficile de s’y retrouver.

--- a/content/edu/les-donnees-a-caractere-personnel-en-milieu-scolaire.md
+++ b/content/edu/les-donnees-a-caractere-personnel-en-milieu-scolaire.md
@@ -6,7 +6,7 @@ videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/04158691-0e9e-40cd-b77
 videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/04158691-0e9e-40cd-b777-925e2f83c535-1080-fragmented.mp4
 ---
 
-## Script
+## Transcription
 
 Lorsqu’un élève utilise des outils en ligne – pour répondre à un quiz ou faire un travail collaboratif – il peut laisser des informations qui permettent de l’identifier. Même s’il utilise un pseudo !
 Et oui : les données à caractère personnel en milieu scolaire, ce n'est pas juste le nom et prénom. Et ça ne concerne pas que le numérique !

--- a/content/edu/les-erun-acteurs-du-numerique-educatif.md
+++ b/content/edu/les-erun-acteurs-du-numerique-educatif.md
@@ -6,7 +6,7 @@ videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/8e1c457b-4bc8-44b2-b6e
 videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/8e1c457b-4bc8-44b2-b6e6-cbac4f611442-1080-fragmented.mp4
 ---
 
-## Script
+## Transcription
 
 Elle, c’est Sarah. Elle est eRUN dans le département des Bas-de-France. Un eRUN, c’est un enseignant référent aux usages du numérique. Quelles sont ses principales missions ? Avec qui travaille-t-il ? Pour le savoir, passons une journée avec Sarah.
 Sarah est professeure des écoles déchargée de classe à temps plein pour des missions d’accompagnement liées au numérique. D’autres eRUN sont à mi-temps. Elle est rattachée à une circonscription et elle dépend hiérarchiquement de son IEN.

--- a/content/edu/les-fonctionnalites-de-retroaction-des-outils-de-quiz-en-ligne.md
+++ b/content/edu/les-fonctionnalites-de-retroaction-des-outils-de-quiz-en-ligne.md
@@ -6,7 +6,7 @@ videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/bf1c9c80-1d0a-4f99-9de
 videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/bf1c9c80-1d0a-4f99-9de5-dc488ef9e24f-1080-fragmented.mp4
 ---
 
-## Script
+## Transcription
 
 En classe, l’enseignant échange de vive voix avec chaque élève sur ses productions. Avec les commentaires notés sur les copies, c’est la manière la plus commune de faire ce que l’on appelle « une rétroaction ».
 Plus une rétroaction est individualisée et détaillée, plus elle a de chances d’être efficace.

--- a/content/edu/les-referents-numeriques-pour-le-second-degre.md
+++ b/content/edu/les-referents-numeriques-pour-le-second-degre.md
@@ -6,7 +6,7 @@ videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/f46785b1-9043-4770-8b5
 videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/f46785b1-9043-4770-8b51-761b54f84988-1080-fragmented.mp4
 ---
 
-## Script
+## Transcription
 
 Qu'il s’agisse de se former sur un nouveau logiciel, de s’initier à l’utilisation de l’ENT ou de
 lancer un projet de webradio au lycée, tout enseignant peut compter sur le soutien du

--- a/content/edu/les-systemes-robotises-de-telepresence.md
+++ b/content/edu/les-systemes-robotises-de-telepresence.md
@@ -6,7 +6,7 @@ videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/4954a3c4-804d-4346-90b
 videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/4954a3c4-804d-4346-90b0-024a18d07674-1080-fragmented.mp4
 ---
 
-## Script
+## Transcription
 
 Il arrive qu’un élève ne puisse pas assister à certains cours sur une longue période pour raison de santé.
 Comment assurer dès lors la continuité des apprentissages ?

--- a/content/edu/les-travaux-academiques-mutualises.md
+++ b/content/edu/les-travaux-academiques-mutualises.md
@@ -6,7 +6,7 @@ videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/e2cc7464-70ab-4f8c-a06
 videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/e2cc7464-70ab-4f8c-a069-5112c2896477-1080-fragmented.mp4
 ---
 
-## Script
+## Transcription
 
 Le numérique offre de nouveaux chemins pédagogiques. Mais ces voies doivent être explorées avant d’être praticables ! C’est pour cette raison qu’ont été créés les Travaux académiques mutualisés ou TraAM.
 – Quelles sont les missions des TraAM ?

--- a/content/edu/methodes-et-outils-pour-concevoir-une-capsule-video.md
+++ b/content/edu/methodes-et-outils-pour-concevoir-une-capsule-video.md
@@ -6,7 +6,7 @@ videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/cb5b4cc7-63df-4cfc-9b8
 videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/cb5b4cc7-63df-4cfc-9b81-3dd8c92e2e90-1080-fragmented.mp4
 ---
 
-## Script
+## Transcription
 
 Parmi la myriade de supports pédagogiques qu’il est possible de concevoir, le format vidéo peut être un formidable outil pour enrichir son cours : pour montrer des choses qui ne sont pas visibles en classe autrement et parce qu'une capsule vidéo peut être revue autant de fois que nécessaire.
 La vidéo offre une grande liberté de création et un vaste champ des possibles.

--- a/content/edu/methodes-et-outils-pour-le-montage-d-une-capsule-video.md
+++ b/content/edu/methodes-et-outils-pour-le-montage-d-une-capsule-video.md
@@ -6,7 +6,7 @@ videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/992760ea-c778-4f45-b7f
 videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/992760ea-c778-4f45-b7fe-ff427c2c49db-1080-fragmented.mp4
 ---
 
-## Script
+## Transcription
 
 Un smartphone ou une tablette permettent de filmer facilement en vue de créer une capsule vidéo... Mais pour un résultat à la hauteur de ses attentes, l’étape du montage est souvent incontournable !
 Le montage va donner corps à ce que vous avez filmé :  choix et agencement des plans, ajout de commentaires audio, d'éléments graphiques, de musique... Autant d’actions qui multiplient le nombre de possibilités de réaliser la capsule qui correspond le mieux à vos besoins !

--- a/content/edu/mettre-en-place-une-strategie-de-veille.md
+++ b/content/edu/mettre-en-place-une-strategie-de-veille.md
@@ -6,7 +6,7 @@ videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/c6d0bc8a-be09-4e15-a2f
 videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/c6d0bc8a-be09-4e15-a2f5-6aff8c3780ce-1080-fragmented.mp4
 ---
 
-## Script
+## Transcription
 
 Ressources pédagogiques, nouveaux programmes, référentiels de compétences...
 Un enseignant est amené à s’informer sur de nombreux sujets. Cette collecte d’informations, leur sélection et leur organisation s’appellent la veille pédagogique. Mais attention : si elle est incontournable, la veille peut aussi devenir chronophage.

--- a/content/edu/outils-pour-rendre-un-document-accessible.md
+++ b/content/edu/outils-pour-rendre-un-document-accessible.md
@@ -6,7 +6,7 @@ videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/71d601ca-6f19-4f7b-890
 videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/71d601ca-6f19-4f7b-8904-dc074e4bfb7f-1080-fragmented.mp4
 ---
 
-## Script
+## Transcription
 
 Emma est une jeune enseignante de CM2. Elle a à cœur de prendre en compte la diversité de ses élèves et de construire des situations d’enseignement et d’apprentissage accessibles à tous, 2 compétences de son référentiel professionnel.
 Quand ses élèves sont en activité, Emma les observe :  certains ont du mal à débuter ou effectuer les exercices proposés pour des raisons qui n'ont pas de lien direct avec l'activité, comme des problèmes de lecture. Elle souhaite comprendre plus en détails ce qui les bloque et comment les aider

--- a/content/edu/partager-et-diffuser-sa-veille-informationnelle.md
+++ b/content/edu/partager-et-diffuser-sa-veille-informationnelle.md
@@ -6,7 +6,7 @@ videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/be916f45-3257-477f-a06
 videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/be916f45-3257-477f-a060-10fb46564e83-1080-fragmented.mp4
 ---
 
-## Script
+## Transcription
 
 Caroline est enseignante de SVT. Pour préparer ses cours, s’informer sur des dispositifs pédagogiques existants ou encore suivre l’actualité institutionnelle, elle peut mener une veille informationnelle. Pour que celle-ci soit plus efficace mais aussi plus profitable à la communauté éducative, elle peut l’organiser, la mutualiser, la partager... grâce à des outils d'agrégation de contenu et de curation.
 Alors, quels outils utiliser pour organiser et partager sa veille ? Qu’est-ce que la curation et à quoi sert-elle ? Comment partager sa veille avec ses collègues et ses élèves ?

--- a/content/edu/reperer-une-copie-ayant-eu-recours-au-plagiat.md
+++ b/content/edu/reperer-une-copie-ayant-eu-recours-au-plagiat.md
@@ -6,7 +6,7 @@ videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/4d4ee6cd-cc4d-4253-926
 videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/4d4ee6cd-cc4d-4253-9269-979a89835099-1080-fragmented.mp4
 ---
 
-## Script
+## Transcription
 
 Lors de la correction de copies, il arrive de découvrir la réponse parfaite à une question posée. Oui mais… et si cela ne venait pas vraiment de l’élève ? Si c’était du plagiat ?
 A l’ère du numérique, les travaux de recherche personnelle des élèves ont fortement changé.

--- a/content/edu/resoudre-des-problemes-simples-lies-aux-outils-numeriques.md
+++ b/content/edu/resoudre-des-problemes-simples-lies-aux-outils-numeriques.md
@@ -6,7 +6,7 @@ videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/4d5da479-0fe2-4e63-bef
 videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/4d5da479-0fe2-4e63-befd-ad3082fed30f-1080-fragmented.mp4
 ---
 
-## Script
+## Transcription
 
 Un écran qui ne s'allume pas ?
 Une piste audio muette ?

--- a/content/edu/savoir-indexer-une-ressource-en-ligne-pour-la-partager.md
+++ b/content/edu/savoir-indexer-une-ressource-en-ligne-pour-la-partager.md
@@ -6,7 +6,7 @@ videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/3ad05af3-1ed3-4db7-894
 videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/3ad05af3-1ed3-4db7-8944-ff1286ed0d68-1080-fragmented.mp4
 ---
 
-## Script
+## Transcription
 
 Ça y est, j’ai créé ma séance d'aquaponey sur mon blog. Mais, pour la partager avec d’autres enseignants, sur certaines plate-formes, on me demande de l’indexer. Ohoh… Comment faire ?
 

--- a/content/edu/scenariser-une-capsule-video.md
+++ b/content/edu/scenariser-une-capsule-video.md
@@ -6,7 +6,7 @@ videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/e4c4a8af-4f7d-42db-ac6
 videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/e4c4a8af-4f7d-42db-ac6e-cc1ab09714e5-1080-fragmented.mp4
 ---
 
-## Script
+## Transcription
 
 Lorsque l’on a une idée de capsule vidéo, on a envie de s'y mettre immédiatement, d'amorcer tout de suite le tournage !
 Mais pour un résultat à la hauteur de ses attentes et pour mettre son énergie et son temps au bon endroit, il est essentiel de passer par une phase préparatoire, la scénarisation. Elle permettra de gagner du temps au tournage et au montage.

--- a/content/edu/se-connecter-a-sa-messagerie-academique.md
+++ b/content/edu/se-connecter-a-sa-messagerie-academique.md
@@ -6,7 +6,7 @@ videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/09090670-0b40-478d-86b
 videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/09090670-0b40-478d-86b7-383451e602e8-1080-fragmented.mp4
 ---
 
-## Script
+## Transcription
 
 Beaucoup d’informations passent aujourd’hui par votre messagerie académique, c’est
 pourquoi il est nécessaire de la consulter régulièrement.

--- a/content/edu/sites-ressources-pour-l-ecole-inclusive.md
+++ b/content/edu/sites-ressources-pour-l-ecole-inclusive.md
@@ -6,7 +6,7 @@ videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/2e8aadf8-45d5-4b1b-b8f
 videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/2e8aadf8-45d5-4b1b-b8f6-b232f8fb3792-1080-fragmented.mp4
 ---
 
-## Script
+## Transcription
 
 Quels que soient leur singularité ou leurs besoins éducatifs particuliers, tous les élèves ont droit à une scolarisation de qualité.
 Karim est enseignant de mathématiques en collège.

--- a/content/edu/suivre-les-avancees-de-la-recherche-sur-le-numerique-educatif.md
+++ b/content/edu/suivre-les-avancees-de-la-recherche-sur-le-numerique-educatif.md
@@ -6,7 +6,7 @@ videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/4b76c54c-4ea7-46f7-964
 videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/4b76c54c-4ea7-46f7-9643-2617f7ba8eb1-1080-fragmented.mp4
 ---
 
-## Script
+## Transcription
 
 Quand on enseigne, on est amené à se questionner sur nos pratiques.
 La recherche en éducation est à même de nourrir ces réflexions et donner des clés pour améliorer notre enseignement.

--- a/content/edu/trouver-et-proposer-des-ressources-pour-le-site-prim-a-bord.md
+++ b/content/edu/trouver-et-proposer-des-ressources-pour-le-site-prim-a-bord.md
@@ -6,7 +6,7 @@ videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/4c0e95cc-9e00-4193-af2
 videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/4c0e95cc-9e00-4193-af2f-7f7f341eceee-1080-fragmented.mp4
 ---
 
-## Script
+## Transcription
 
 Axel, enseignant en CM1, souhaite développer le travail collaboratif avec ses élèves à l’aide du numérique. Où peut-il trouver des ressources sur lesquelles s’appuyer ?
 Ses collègues lui ont conseillé d’aller sur le portail Prim à bord…

--- a/content/edu/utiliser-des-capsules-video-en-classe.md
+++ b/content/edu/utiliser-des-capsules-video-en-classe.md
@@ -6,7 +6,7 @@ videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/68d966e7-76f4-4ff2-854
 videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/68d966e7-76f4-4ff2-8544-ab9a86c1b815-1080-fragmented.mp4
 ---
 
-## Script
+## Transcription
 
 Avec ses élèves, on ressent parfois le besoin de varier ses méthodes et ses supports pour transmettre des savoirs et des savoir-faire.
 La vidéo peut être un support qui va susciter l'intérêt des élèves et les échanges, à utiliser en cours ou hors de la classe.

--- a/content/edu/utiliser-les-outils-de-quiz-en-ligne-pour-diversifier-son-evaluation.md
+++ b/content/edu/utiliser-les-outils-de-quiz-en-ligne-pour-diversifier-son-evaluation.md
@@ -6,7 +6,7 @@ videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/3a19ecea-b46e-479b-9bc
 videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/3a19ecea-b46e-479b-9bcc-7268b744534e-1080-fragmented.mp4
 ---
 
-## Script
+## Transcription
 
 Pour accompagner et suivre l’évolution des élèves dans leurs apprentissages, un levier efficace est de leur poser les bonnes questions au bon moment.
 Des évaluations régulières et variées permettent de mesurer si les compétences et savoirs visés sont acquis et d’adapter son cours en conséquence. En accompagnant les élèves dans l’analyse de ce qu’ils ont acquis ou pas encore, on agit sur leur motivation à apprendre.

--- a/content/edu/utiliser-un-tni.md
+++ b/content/edu/utiliser-un-tni.md
@@ -6,7 +6,7 @@ videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/a948661e-2ee2-4250-9ee
 videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/a948661e-2ee2-4250-9ee9-04dfde2d8753-1080-fragmented.mp4
 ---
 
-## Script
+## Transcription
 
 Avez-vous déjà entendu parler de TNI ou de TBI ?
 Ces deux appellations désignent en fait la même chose : un dispositif de vidéoprojection interactif.

--- a/content/edu/utiliser-une-illustration-en-licence-libre.md
+++ b/content/edu/utiliser-une-illustration-en-licence-libre.md
@@ -6,7 +6,7 @@ videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/3a09576d-cf6c-4d3d-a92
 videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/3a09576d-cf6c-4d3d-a920-e7f537f1a9ff-1080-fragmented.mp4
 ---
 
-## Script
+## Transcription
 
 « Un bon croquis vaut mieux qu’un long discours. »
 En utilisant des images pour illustrer vos enseignements, vous pourrez étoffer votre propos et obtenir davantage d’attention de la part de vos élèves.

--- a/layouts/edu.vue
+++ b/layouts/edu.vue
@@ -4,11 +4,20 @@
     class="app-viewport"
   >
     <PixHeader :hide-actions="false" />
+
     <main
       role="main"
       class="main-container"
     >
       <slot />
+
+      <section class="partners">
+        <img
+          class=""
+          src="~/assets/images/partners.png"
+          alt="Financé par le Gouvernement de la République française, liberté égalité fraternité, le plan France Relance et l'Union européenne (NextGenerationEU)"
+        >
+      </section>
     </main>
   </div>
 </template>
@@ -28,6 +37,20 @@
   padding: 4rem 1rem;
   max-width: 980px;
   margin: 0 auto;
+}
+
+.partners {
+  margin-top: 48px;
+  padding: 32px 0;
+  border-top: 1px solid $pix-neutral-20;
+  border-bottom: 1px solid $pix-neutral-20;
+
+  img {
+    display: block;
+    width: 450px;
+    max-width: 100%;
+    margin: 0 auto;
+  }
 }
 
 @media print {

--- a/pages/edu/index.vue
+++ b/pages/edu/index.vue
@@ -1,12 +1,5 @@
 <template>
   <div>
-    <section class="header__partners">
-      <img
-        src="~/assets/images/partners.png"
-        alt="Financé par le Gouvernement de la République française, liberté égalité fraternité, le plan France Relance et l'Union européenne (NextGenerationEU)"
-      >
-    </section>
-
     <h1 class="header__title">
       Tutoriels Réseau Canopé-Pix
     </h1>
@@ -87,20 +80,6 @@ ul {
 }
 
 .header {
-  &__partners {
-    margin-bottom: 48px;
-    padding: 32px 0;
-    border-top: 1px solid $pix-neutral-20;
-    border-bottom: 1px solid $pix-neutral-20;
-
-    img {
-      display: block;
-      width: 450px;
-      max-width: 100%;
-      margin: 0 auto;
-    }
-  }
-
   &__title {
     margin-bottom: 8px;
   }


### PR DESCRIPTION
## :unicorn: Problème & :robot: Proposition
On souhaite afficher les logos de partenaires sur toutes les pages de `/edu`, y compris à l'impression. On les place en fin de page.

On renomme également les occurrences de "script" et "transcript" en "transcription" qui est plus correct grammaticalement.

## :rainbow: Remarques
RAS

## :100: Pour tester
Vérifier sur la RA que `/edu` a bien les logos de partenaires en bas de page et l'utilisation du terme "transcription" partout.
