### PR TITLE
[FEATURE] A l'impression, ajouter le logo de Pix

### DIFF
--- a/layouts/edu.vue
+++ b/layouts/edu.vue
@@ -9,6 +9,12 @@
       role="main"
       class="main-container"
     >
+      <img
+        src="~/assets/images/pix-logo.svg"
+        class="logo"
+        alt="Pix"
+      >
+
       <slot />
 
       <section class="partners">
@@ -53,6 +59,11 @@
   }
 }
 
+.logo {
+  display: none;
+  width: 100px;
+}
+
 @media print {
   #app {
     background-color: $pix-neutral-0;
@@ -65,6 +76,10 @@
   // Nous mettons le !important pour éviter la surcharge du style par celui de la page qui est appliqué ensuite.
   .main-header, .tuto__description, .tuto__video, .tuto__actions {
     display: none !important;
+  }
+
+  .logo {
+    display: block;
   }
 }
 </style>


### PR DESCRIPTION
## :unicorn: Problème
A l'impression, on a pas le logo pix

## :robot: Proposition
Ajouter le logo sur l'impression pix quand les utilisateurs vont telecharger la transcription

## :rainbow: Remarques
Pas des remarques

## :100: Pour tester
Aller sur pix.tuto
cliquer sur un tuto
cliquer sur le bouton "telecharger la transcription"
Verifier que le logo pix et bien ajouter sur la haute gauche de l'impression
