### PR TITLE
[BREAKING] Ajoute des `id` aux boutons d'action pour Matomo

### DIFF
--- a/components/PixTutorial.vue
+++ b/components/PixTutorial.vue
@@ -17,11 +17,11 @@
       class="tuto__actions"
     >
       <li
-        v-if="videoDlHref"
+        v-if="videoDownloadHref"
         class="tuto-actions__item"
       >
         <PixButtonLink
-          :href="videoDlHref"
+          :href="videoDownloadHref"
           target="_blank"
           rel="noopener noreferrer"
         >
@@ -67,7 +67,7 @@ export default {
       type: String,
       required: true,
     },
-    videoDlHref: {
+    videoDownloadHref: {
       type: String,
       default: null,
     },

--- a/components/PixTutorial.vue
+++ b/components/PixTutorial.vue
@@ -14,7 +14,6 @@
     />
 
     <ul
-      v-if="videoDlHref || fichePdfHref || transcriptPdfHref"
       class="tuto__actions"
     >
       <li

--- a/components/PixTutorial.vue
+++ b/components/PixTutorial.vue
@@ -21,6 +21,7 @@
         class="tuto-actions__item"
       >
         <PixButtonLink
+          id="download-video"
           :href="videoDownloadHref"
           target="_blank"
           rel="noopener noreferrer"
@@ -32,6 +33,7 @@
         class="tuto-actions__item"
       >
         <PixButton
+          id="download-transcript"
           :action="downloadTranscript"
         >
           Télécharger la transcription

--- a/components/PixTutorial.vue
+++ b/components/PixTutorial.vue
@@ -29,31 +29,6 @@
         </PixButtonLink>
       </li>
       <li
-        v-if="fichePdfHref"
-        class="tuto-actions__item"
-      >
-        <PixButtonLink
-          :href="fichePdfHref"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Télécharger la fiche
-        </PixButtonLink>
-      </li>
-      <li
-        v-if="transcriptPdfHref"
-        class="tuto-actions__item"
-      >
-        <PixButtonLink
-          :href="transcriptPdfHref"
-          background-color="transparent-light"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Télécharger la retranscription
-        </PixButtonLink>
-      </li>
-      <li
         class="tuto-actions__item"
       >
         <PixButton
@@ -93,14 +68,6 @@ export default {
       required: true,
     },
     videoDlHref: {
-      type: String,
-      default: null,
-    },
-    fichePdfHref: {
-      type: String,
-      default: null,
-    },
-    transcriptPdfHref: {
       type: String,
       default: null,
     },

--- a/content/edu/agir-face-au-cyberharcelement.md
+++ b/content/edu/agir-face-au-cyberharcelement.md
@@ -3,7 +3,7 @@ area: Domaine 1
 title: Agir face au cyberharcèlement
 description: Dans cette vidéo, vous trouverez des conseils et des pistes pour agir en tant que professionnel de l'éducation lorsque vous êtes témoin de situations de cyberharcèlement entre élèves.
 videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/17831907-e7cb-439a-a5c8-2e0453c878e3
-videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/17831907-e7cb-439a-a5c8-2e0453c878e3-1080-fragmented.mp4
+videoDownloadHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/17831907-e7cb-439a-a5c8-2e0453c878e3-1080-fragmented.mp4
 ---
 
 ## Transcription

--- a/content/edu/appliquer-l-exception-pedagogique-et-les-exceptions-aux-droits-d-auteur.md
+++ b/content/edu/appliquer-l-exception-pedagogique-et-les-exceptions-aux-droits-d-auteur.md
@@ -3,7 +3,7 @@ area: Domaine 2
 title: Appliquer l'exception pédagogique et les exceptions aux droits d'auteur
 description: Dans cette vidéo, vous verrez en détail ce que permet l'exception pédagogique pour respecter la propriété intellectuelle de chacun. Quelles ressources peuvent être utilisées ? Sous quelles conditions ? Toutes les réponses dans la vidéo !
 videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/4512d4a2-2f3f-42e0-8958-8e6ffbb6561e
-videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/4512d4a2-2f3f-42e0-8958-8e6ffbb6561e-1080-fragmented.mp4
+videoDownloadHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/4512d4a2-2f3f-42e0-8958-8e6ffbb6561e-1080-fragmented.mp4
 ---
 
 ## Transcription

--- a/content/edu/cadre-et-acteurs-du-rgpd-en-milieu-scolaire.md
+++ b/content/edu/cadre-et-acteurs-du-rgpd-en-milieu-scolaire.md
@@ -3,7 +3,7 @@ area: Domaine 1
 title: Cadre et acteurs du RGPD en milieu scolaire
 description: Qu'elles soient administratives ou pédagogiques, les données à caractère personnel des élèves doivent être protégées. Le registre de traitement des données personnelles est un outil central au respect du RGPD en milieu scolaire. Prêt à en savoir plus ?
 videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/4d2fd5f5-adca-4ccb-9208-a4796f68d038
-videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/4d2fd5f5-adca-4ccb-9208-a4796f68d038-1080-fragmented.mp4
+videoDownloadHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/4d2fd5f5-adca-4ccb-9208-a4796f68d038-1080-fragmented.mp4
 ---
 
 ## Transcription

--- a/content/edu/communiquer-efficacement-par-differents-canaux-aupres-de-ses-eleves.md
+++ b/content/edu/communiquer-efficacement-par-differents-canaux-aupres-de-ses-eleves.md
@@ -3,7 +3,7 @@ area : Domaine 1
 title: Communiquer efficacement par différents canaux auprès de ses élèves
 description: Les canaux numériques pour communiquer avec ses élèves sont très nombreux. Quel canal choisir ? C'est ce que nous allons voir dans cette vidéo.
 videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/31ea90d9-6d86-49b1-b6e1-4cc008000dbe
-videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/31ea90d9-6d86-49b1-b6e1-4cc008000dbe-1080-fragmented.mp4
+videoDownloadHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/31ea90d9-6d86-49b1-b6e1-4cc008000dbe-1080-fragmented.mp4
 ---
 
 ## Transcription

--- a/content/edu/communiquer-par-voie-numerique-aupres-de-la-communaute-educative.md
+++ b/content/edu/communiquer-par-voie-numerique-aupres-de-la-communaute-educative.md
@@ -3,7 +3,7 @@ area: Domaine 1
 title: Communiquer par voie numérique auprès de la communauté éducative
 description: "Élèves, parents, partenaires : quels moyens de communications privilégier en tant qu'enseignant ? Plus d'informations dans cette vidéo."
 videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/ef3f3ced-c2ee-41c0-91c7-1b7ad83f0de5
-videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/ef3f3ced-c2ee-41c0-91c7-1b7ad83f0de5-1080-fragmented.mp4
+videoDownloadHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/ef3f3ced-c2ee-41c0-91c7-1b7ad83f0de5-1080-fragmented.mp4
 ---
 
 ## Transcription

--- a/content/edu/comprendre-comment-differencier-grace-au-numerique.md
+++ b/content/edu/comprendre-comment-differencier-grace-au-numerique.md
@@ -3,7 +3,7 @@ area: Domaine 4
 title: Différencier ses pratiques pédagogiques grâce au numérique
 description: Décliner et adapter les situations et les supports pédagogiques pour répondre aux besoins éducatifs particuliers des élèves sont de réels enjeux pour les enseignants. Dans cette vidéo, nous verrons comment certains outils numériques peuvent aider ce travail de différenciation.
 videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/9520b54d-0a3c-43dc-8821-d559fa418cc6
-videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/9520b54d-0a3c-43dc-8821-d559fa418cc6-1080-fragmented.mp4
+videoDownloadHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/9520b54d-0a3c-43dc-8821-d559fa418cc6-1080-fragmented.mp4
 ---
 
 ## Transcription

--- a/content/edu/comprendre-les-creative-commons-pour-une-utilisation-pedagogique.md
+++ b/content/edu/comprendre-les-creative-commons-pour-une-utilisation-pedagogique.md
@@ -3,7 +3,7 @@ area: Domaine 2
 title: Comprendre les Creative Commons pour une utilisation pédagogique
 description: Les ressources en licence Creative Commons (CC) peuvent être des ressources précieuses lors de la création d'un support pédagogique. Voici comment s'y retrouver entre les différents types de licences CC.
 videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/17d63f12-2a68-4110-8943-dba74582befd
-videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/17d63f12-2a68-4110-8943-dba74582befd-1080-fragmented.mp4
+videoDownloadHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/17d63f12-2a68-4110-8943-dba74582befd-1080-fragmented.mp4
 ---
 
 ## Transcription

--- a/content/edu/configurer-son-client-de-messagerie-pour-recevoir-ses-mails-academiques.md
+++ b/content/edu/configurer-son-client-de-messagerie-pour-recevoir-ses-mails-academiques.md
@@ -3,7 +3,7 @@ area: Domaine 1
 title: Configurer son client de messagerie pour recevoir ses mails académiques
 description: Pour éviter de jongler entre différentes boîtes mails, il est possible d'utiliser un client de messagerie pour centraliser ses emails. Toutes les informations dans cette vidéo !
 videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/4009d7ec-c48a-4a13-8198-7a083af3d61f
-videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/4009d7ec-c48a-4a13-8198-7a083af3d61f-1080-fragmented.mp4
+videoDownloadHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/4009d7ec-c48a-4a13-8198-7a083af3d61f-1080-fragmented.mp4
 ---
 
 ## Transcription

--- a/content/edu/connaitre-des-applications-a-videoprojeter-pour-animer-et-gerer-sa-classe.md
+++ b/content/edu/connaitre-des-applications-a-videoprojeter-pour-animer-et-gerer-sa-classe.md
@@ -3,7 +3,7 @@ area: Domaine 3
 title: Connaître des applications à vidéoprojeter pour animer et gérer sa classe
 description: "Tirage au sort, chronomètre, QR code, fichier audio : beaucoup d'outils existent de manière indépendante. Certaines applications centralisent toutes ces fonctionnalités pour permettre d'animer, de gérer des activités et les différents moments d'un cours. Les détails dans cette vidéo !"
 videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/b83d2ab8-e18f-4156-9eda-8a49f8a59de9
-videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/b83d2ab8-e18f-4156-9eda-8a49f8a59de9-1080-fragmented.mp4
+videoDownloadHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/b83d2ab8-e18f-4156-9eda-8a49f8a59de9-1080-fragmented.mp4
 ---
 
 ## Transcription

--- a/content/edu/connaitre-des-outils-de-quiz-en-ligne.md
+++ b/content/edu/connaitre-des-outils-de-quiz-en-ligne.md
@@ -3,7 +3,7 @@ area: Domaine 3
 title: Connaître des outils de quiz en ligne
 description: Pour obtenir facilement et en temps réel les résultats d'une classe à un exercice, un quiz en ligne constitue un précieux allié. Mais quel outil de quiz choisir ? Des éléments de réponse dans cette vidéo !
 videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/2fc37e8d-860d-4789-a092-e6ca3b113943
-videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/2fc37e8d-860d-4789-a092-e6ca3b113943-1080-fragmented.mp4
+videoDownloadHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/2fc37e8d-860d-4789-a092-e6ca3b113943-1080-fragmented.mp4
 ---
 
 ## Transcription

--- a/content/edu/identifier-des-sources-de-veille-incontournables.md
+++ b/content/edu/identifier-des-sources-de-veille-incontournables.md
@@ -3,7 +3,7 @@ area: Domaine 1
 title: Identifier des sources de veille incontournables
 description: Pour éviter l'infobésité, la sélection de ses sources de veille est primordial. Dans cette vidéo, quelques sources de veille importantes de la sphère éducative qui peuvent vous intéresser !
 videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/b456fcdb-64d5-425e-8ff2-c023e9cb9543
-videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/b456fcdb-64d5-425e-8ff2-c023e9cb9543-1080-fragmented.mp4
+videoDownloadHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/b456fcdb-64d5-425e-8ff2-c023e9cb9543-1080-fragmented.mp4
 ---
 
 ## Transcription

--- a/content/edu/la-classe-inversee.md
+++ b/content/edu/la-classe-inversee.md
@@ -3,7 +3,7 @@ area: Domaine 3
 title: La classe inversée
 description: La classe inversée est souvent présentée comme un moyen de responsabiliser les élèves, de les rendre actifs tout en leur accordant une grande autonomie. Les détails dans cette vidéo !
 videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/9d109c46-311c-49ce-826e-406581233be0
-videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/9d109c46-311c-49ce-826e-406581233be0-1080-fragmented.mp4
+videoDownloadHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/9d109c46-311c-49ce-826e-406581233be0-1080-fragmented.mp4
 ---
 
 ## Transcription

--- a/content/edu/le-cadre-de-reference-des-competences-numeriques.md
+++ b/content/edu/le-cadre-de-reference-des-competences-numeriques.md
@@ -3,7 +3,7 @@ area: Domaine 5
 title: Le Cadre de référence des compétences numériques (CRCN)
 description: Inspiré du cadre européen DigComp, le Cadre de référence des compétences numériques (CRCN) structure les savoirs et savoir-faire relatifs au numérique pour aider les enseignants et leurs élèves au développement de ces compétences dans le cadre scolaire. Prêt à en savoir encore plus sur le CRCN ?
 videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/1d82b613-ee83-4b08-895d-61a10aa8ecdb
-videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/1d82b613-ee83-4b08-895d-61a10aa8ecdb-1080-fragmented.mp4
+videoDownloadHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/1d82b613-ee83-4b08-895d-61a10aa8ecdb-1080-fragmented.mp4
 ---
 
 ## Transcription

--- a/content/edu/le-cahier-de-texte-numerique.md
+++ b/content/edu/le-cahier-de-texte-numerique.md
@@ -3,7 +3,7 @@ area: Domaine 5
 title: Le cahier de texte numérique
 description: Objet emblématique d'une classe, le cahier de texte est désormais au format numérique. Ce format permet d'en faire un outil partagé et qui présente de nouvelles fonctionnalités. Plus de détails dans cette vidéo !
 videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/d797ea7c-77f3-45fc-b47a-823cb63745b9
-videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/d797ea7c-77f3-45fc-b47a-823cb63745b9-1080-fragmented.mp4
+videoDownloadHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/d797ea7c-77f3-45fc-b47a-823cb63745b9-1080-fragmented.mp4
 ---
 
 ## Transcription

--- a/content/edu/le-cyberharcelement.md
+++ b/content/edu/le-cyberharcelement.md
@@ -3,7 +3,7 @@ area: Domaine 1
 title: Le cyberharcèlement
 description: Malheureusement d'actualité, les situations de cyberharcèlement progressent en milieu scolaire. Comment lutter contre ces situations et accompagner les personnes concernées ?
 videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/ef2ca374-d224-4440-960c-69d335973a52
-videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/ef2ca374-d224-4440-960c-69d335973a52-1080-fragmented.mp4
+videoDownloadHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/ef2ca374-d224-4440-960c-69d335973a52-1080-fragmented.mp4
 ---
 
 ## Transcription

--- a/content/edu/le-droit-a-l-image-des-eleves.md
+++ b/content/edu/le-droit-a-l-image-des-eleves.md
@@ -3,7 +3,7 @@ area: Domaine 1
 title: Le droit à l'image des élèves
 description: Comme tout citoyen, les élèves disposent d'un droit à l'image. Comment le respecter au mieux en tant qu'enseignant ? C'est ce que nous allons voir dans cette vidéo.
 videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/21e4730e-59f2-4363-bb8f-7425e4031cc0
-videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/21e4730e-59f2-4363-bb8f-7425e4031cc0-1080-fragmented.mp4
+videoDownloadHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/21e4730e-59f2-4363-bb8f-7425e4031cc0-1080-fragmented.mp4
 ---
 
 ## Transcription

--- a/content/edu/le-droit-d-auteur-des-eleves.md
+++ b/content/edu/le-droit-d-auteur-des-eleves.md
@@ -3,7 +3,7 @@ area: Domaine 2
 title: Le droit d'auteur des élèves
 description: Les élèves disposent, comme tout citoyen, d'un droit d'auteur sur leurs créations produites à l'école. Comment respecter au mieux ce droit en tant qu'enseignant ?
 videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/ef12284a-5da4-478f-83fa-51db88b9ce9d
-videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/ef12284a-5da4-478f-83fa-51db88b9ce9d-1080-fragmented.mp4
+videoDownloadHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/ef12284a-5da4-478f-83fa-51db88b9ce9d-1080-fragmented.mp4
 ---
 
 ## Transcription

--- a/content/edu/le-modele-samr-pour-integrer-le-numerique-dans-la-pedagogie.md
+++ b/content/edu/le-modele-samr-pour-integrer-le-numerique-dans-la-pedagogie.md
@@ -3,7 +3,7 @@ area: Domaine 1
 title: Le modèle SAMR pour intégrer le numérique dans la pédagogie
 description: Le modèle théorique SAMR est issu de la recherche. Il permet d'interroger l'usage du numérique dans une activité pédagogique afin d'estimer dans quelle mesure cette utilisation modifie les tâches menées par les élèves. Plus d'informations dans cette vidéo !
 videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/fb9ee01b-1d22-404d-8496-d14c0c698796
-videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/fb9ee01b-1d22-404d-8496-d14c0c698796-1080-fragmented.mp4
+videoDownloadHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/fb9ee01b-1d22-404d-8496-d14c0c698796-1080-fragmented.mp4
 ---
 
 ## Transcription

--- a/content/edu/le-modele-tpack-pour-integrer-le-numerique-dans-la-pedagogie.md
+++ b/content/edu/le-modele-tpack-pour-integrer-le-numerique-dans-la-pedagogie.md
@@ -3,7 +3,7 @@ area: Domaine 1
 title: Le modèle TPaCK pour intégrer le numérique dans la pédagogie
 description: Dans leur activité professionnelle, les enseignants sont amenés à mobiliser des compétences pédagogiques, disciplinaires et techniques. Tel est le cadre proposé par le modèle théorique TPaCK afin de les aider à enrichir l'analyse réflexive de leurs pratiques.
 videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/11823461-ed6a-4607-8b7a-e39ba906c481
-videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/11823461-ed6a-4607-8b7a-e39ba906c481-1080-fragmented.mp4
+videoDownloadHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/11823461-ed6a-4607-8b7a-e39ba906c481-1080-fragmented.mp4
 ---
 
 ## Transcription

--- a/content/edu/le-principe-de-l-exception-pedagogique.md
+++ b/content/edu/le-principe-de-l-exception-pedagogique.md
@@ -3,7 +3,7 @@ area: Domaine 2
 title: Le principe de l'exception pédagogique
 description: Pas toujours facile de respecter la propriété intellectuelle de chacun lors de la conception de supports pédagogiques. L'exception pédagogique a été pensée pour permettre aux enseignants de se saisir de ressources existantes, sous certaines conditions. Tous les détails dans la vidéo !
 videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/48dcc19b-31fb-45a8-acb0-4304d24eaf22
-videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/48dcc19b-31fb-45a8-acb0-4304d24eaf22-1080-fragmented.mp4
+videoDownloadHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/48dcc19b-31fb-45a8-acb0-4304d24eaf22-1080-fragmented.mp4
 ---
 
 ## Transcription

--- a/content/edu/le-rgpd-en-milieu-scolaire.md
+++ b/content/edu/le-rgpd-en-milieu-scolaire.md
@@ -3,7 +3,7 @@ area: Domaine 1
 title: Le RGPD en milieu scolaire
 description: 'Au programme de cette vidéo : une présentation du RGPD et le rôle des personnels des établissements scolaires.'
 videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/80dcdd6b-5c58-4846-9943-1c0d8f6866b9
-videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/80dcdd6b-5c58-4846-9943-1c0d8f6866b9-1080-fragmented.mp4
+videoDownloadHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/80dcdd6b-5c58-4846-9943-1c0d8f6866b9-1080-fragmented.mp4
 ---
 
 ## Transcription

--- a/content/edu/le-site-cap-ecole-inclusive.md
+++ b/content/edu/le-site-cap-ecole-inclusive.md
@@ -3,7 +3,7 @@ area: Domaine 4
 title: Le site Cap école inclusive
 description: "Intéressés par des grilles pour analyser les besoins particuliers de vos élèves ou par une cartographie des acteurs de l'école inclusive en France : le site Cap école inclusive est fait pour vous."
 videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/b2b7cf75-69b2-40db-a35c-164457affaaa
-videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/b2b7cf75-69b2-40db-a35c-164457affaaa-1080-fragmented.mp4
+videoDownloadHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/b2b7cf75-69b2-40db-a35c-164457affaaa-1080-fragmented.mp4
 ---
 
 ## Transcription

--- a/content/edu/learning-analytics-et-intelligence-artificielle-dans-l-education.md
+++ b/content/edu/learning-analytics-et-intelligence-artificielle-dans-l-education.md
@@ -3,7 +3,7 @@ area: Domaine 3
 title: Learning analytics et intelligence artificielle dans l'éducation
 description: Les données éducatives se sont, comme toutes les autres données, massifiées ces dernières années. Comment sont-elles utilisées par le monde de la recherche ? Que nous apprennent-elles ?
 videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/d66e9416-39ee-4d25-bac8-80552dcc463b
-videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/d66e9416-39ee-4d25-bac8-80552dcc463b-1080-fragmented.mp4
+videoDownloadHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/d66e9416-39ee-4d25-bac8-80552dcc463b-1080-fragmented.mp4
 ---
 
 ## Transcription

--- a/content/edu/les-acteurs-de-la-formation-en-ligne-des-enseignants.md
+++ b/content/edu/les-acteurs-de-la-formation-en-ligne-des-enseignants.md
@@ -3,7 +3,7 @@ area: Domaine 1
 title: Les acteurs de la formation en ligne des enseignants
 description: De nombreuses formations en ligne sont proposées par des acteurs du monde éducatif. Découvrez-les dans cette vidéo !
 videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/67df24ff-e146-45ae-8eca-562bce282d50
-videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/67df24ff-e146-45ae-8eca-562bce282d50-1080-fragmented.mp4
+videoDownloadHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/67df24ff-e146-45ae-8eca-562bce282d50-1080-fragmented.mp4
 ---
 
 ## Transcription

--- a/content/edu/les-acteurs-institutionnels-du-numerique-educatif-dans-le-2nd-degre.md
+++ b/content/edu/les-acteurs-institutionnels-du-numerique-educatif-dans-le-2nd-degre.md
@@ -3,7 +3,7 @@ area : Domaine 1
 title: Les acteurs institutionnels du numérique éducatif dans le 2nd degré
 description: Découvrez dans cette vidéo l'ensemble des acteurs au sein de l'Éducation nationale qui ont des missions relatives au numérique éducatif dans le second degré.
 videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/b2d55662-aae2-41f3-8fa0-2b0e6ad4de87
-videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/b2d55662-aae2-41f3-8fa0-2b0e6ad4de87-1080-fragmented.mp4
+videoDownloadHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/b2d55662-aae2-41f3-8fa0-2b0e6ad4de87-1080-fragmented.mp4
 ---
 
 ## Transcription

--- a/content/edu/les-donnees-a-caractere-personnel-en-milieu-scolaire.md
+++ b/content/edu/les-donnees-a-caractere-personnel-en-milieu-scolaire.md
@@ -3,7 +3,7 @@ area: Domaine 1
 title: Les données à caractère personnel en milieu scolaire
 description: 'Au programme de cette vidéo : définir les données personnelles et découvrir les enjeux associés en contexte scolaire.'
 videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/04158691-0e9e-40cd-b777-925e2f83c535
-videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/04158691-0e9e-40cd-b777-925e2f83c535-1080-fragmented.mp4
+videoDownloadHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/04158691-0e9e-40cd-b777-925e2f83c535-1080-fragmented.mp4
 ---
 
 ## Transcription

--- a/content/edu/les-erun-acteurs-du-numerique-educatif.md
+++ b/content/edu/les-erun-acteurs-du-numerique-educatif.md
@@ -3,7 +3,7 @@ area: Domaine 1
 title: Les eRUN, acteurs du numérique éducatif
 description: Les eRUN sont des acteurs incontournables du numérique dans le premier degré. Découvez-en plus concernant leurs missions et leurs responsabilités en visionnant cette vidéo !
 videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/8e1c457b-4bc8-44b2-b6e6-cbac4f611442
-videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/8e1c457b-4bc8-44b2-b6e6-cbac4f611442-1080-fragmented.mp4
+videoDownloadHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/8e1c457b-4bc8-44b2-b6e6-cbac4f611442-1080-fragmented.mp4
 ---
 
 ## Transcription

--- a/content/edu/les-fonctionnalites-de-retroaction-des-outils-de-quiz-en-ligne.md
+++ b/content/edu/les-fonctionnalites-de-retroaction-des-outils-de-quiz-en-ligne.md
@@ -3,7 +3,7 @@ area: Domaine 3
 title: Les fonctionnalités de rétroaction des outils de quiz en ligne
 description: Pour guider un élève lors d'un quiz en ligne, rien de mieux qu'une rétroaction (feedback). Selon l'outil que vous choisirez, vous pourrez plus ou moins personnaliser et détailler vos rétroactions.
 videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/bf1c9c80-1d0a-4f99-9de5-dc488ef9e24f
-videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/bf1c9c80-1d0a-4f99-9de5-dc488ef9e24f-1080-fragmented.mp4
+videoDownloadHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/bf1c9c80-1d0a-4f99-9de5-dc488ef9e24f-1080-fragmented.mp4
 ---
 
 ## Transcription

--- a/content/edu/les-lieux-d-echange-en-ligne-entre-professionnels.md
+++ b/content/edu/les-lieux-d-echange-en-ligne-entre-professionnels.md
@@ -3,5 +3,5 @@ area: Domaine 1
 title: Les lieux d'échange en ligne entre professionnels
 description: De nombreux enseignants échangent en ligne, autour par exemple d'activités, de conseils pratiques ou encore d'idées de projet. Voici dans cette vidéo quelques lieux d'échange en ligne qui peuvent vous intéresser !
 videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/d61113c3-6eeb-479b-a68a-3788e7b60be4
-videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/d61113c3-6eeb-479b-a68a-3788e7b60be4-1080-fragmented.mp4
+videoDownloadHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/d61113c3-6eeb-479b-a68a-3788e7b60be4-1080-fragmented.mp4
 ---

--- a/content/edu/les-referents-numeriques-pour-le-second-degre.md
+++ b/content/edu/les-referents-numeriques-pour-le-second-degre.md
@@ -3,7 +3,7 @@ area : Domaine 1
 title: Les référents numériques pour le second degré
 description: Dans cette vidéo, (re-)découvrez le rôle et les missions d'un référent pour les ressources et usages pédagogiques numériques.
 videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/f46785b1-9043-4770-8b51-761b54f84988
-videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/f46785b1-9043-4770-8b51-761b54f84988-1080-fragmented.mp4
+videoDownloadHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/f46785b1-9043-4770-8b51-761b54f84988-1080-fragmented.mp4
 ---
 
 ## Transcription

--- a/content/edu/les-systemes-robotises-de-telepresence.md
+++ b/content/edu/les-systemes-robotises-de-telepresence.md
@@ -3,7 +3,7 @@ area: Domaine 4
 title: Les systèmes robotisés de téléprésence
 description: Les systèmes robotisés de téléprésence permettent aux élèves empêchés de se rendre à l'école sur une longue période de suivre les cours et garder des liens avec ses camarades. Une vidéo pour en savoir plus.
 videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/4954a3c4-804d-4346-90b0-024a18d07674
-videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/4954a3c4-804d-4346-90b0-024a18d07674-1080-fragmented.mp4
+videoDownloadHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/4954a3c4-804d-4346-90b0-024a18d07674-1080-fragmented.mp4
 ---
 
 ## Transcription

--- a/content/edu/les-travaux-academiques-mutualises.md
+++ b/content/edu/les-travaux-academiques-mutualises.md
@@ -3,7 +3,7 @@ area: Domaine 1
 title: Les Travaux académiques mutualisés (TraAM)
 description: Avez-vous déjà entendu parlé des TraAM ? Ces travaux inter-académiques menés par des enseignants du premier et du second degré abordent des thèmes émergents du numérique éducatif et proposent des scénarios pédagogiques associés. Plus de détails dans cette vidéo !
 videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/e2cc7464-70ab-4f8c-a069-5112c2896477
-videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/e2cc7464-70ab-4f8c-a069-5112c2896477-1080-fragmented.mp4
+videoDownloadHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/e2cc7464-70ab-4f8c-a069-5112c2896477-1080-fragmented.mp4
 ---
 
 ## Transcription

--- a/content/edu/methodes-et-outils-pour-concevoir-une-capsule-video.md
+++ b/content/edu/methodes-et-outils-pour-concevoir-une-capsule-video.md
@@ -3,7 +3,7 @@ area: Domaine 3
 title: Méthodes et outils pour concevoir une capsule vidéo
 description: Il existe de nombreuses manières de créer une capsule vidéo. Si vous hésitez encore, cette vidéo vous éclairera sûrement !
 videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/cb5b4cc7-63df-4cfc-9b81-3dd8c92e2e90
-videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/cb5b4cc7-63df-4cfc-9b81-3dd8c92e2e90-1080-fragmented.mp4
+videoDownloadHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/cb5b4cc7-63df-4cfc-9b81-3dd8c92e2e90-1080-fragmented.mp4
 ---
 
 ## Transcription

--- a/content/edu/methodes-et-outils-pour-le-montage-d-une-capsule-video.md
+++ b/content/edu/methodes-et-outils-pour-le-montage-d-une-capsule-video.md
@@ -3,7 +3,7 @@ area: Domaine 3
 title: Méthodes et outils pour le montage d'une capsule vidéo
 description: Pour supprimmer un temps mort ou un bruit parasite survenu lors de votre captation vidéo, le montage sera votre allié ! Plus d'informations dans cette vidéo
 videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/992760ea-c778-4f45-b7fe-ff427c2c49db
-videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/992760ea-c778-4f45-b7fe-ff427c2c49db-1080-fragmented.mp4
+videoDownloadHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/992760ea-c778-4f45-b7fe-ff427c2c49db-1080-fragmented.mp4
 ---
 
 ## Transcription

--- a/content/edu/mettre-en-place-une-strategie-de-veille.md
+++ b/content/edu/mettre-en-place-une-strategie-de-veille.md
@@ -3,7 +3,7 @@ area: Domaine 1
 title: Mettre en place une stratégie de veille
 description:
 videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/c6d0bc8a-be09-4e15-a2f5-6aff8c3780ce
-videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/c6d0bc8a-be09-4e15-a2f5-6aff8c3780ce-1080-fragmented.mp4
+videoDownloadHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/c6d0bc8a-be09-4e15-a2f5-6aff8c3780ce-1080-fragmented.mp4
 ---
 
 ## Transcription

--- a/content/edu/outils-pour-rendre-un-document-accessible.md
+++ b/content/edu/outils-pour-rendre-un-document-accessible.md
@@ -3,7 +3,7 @@ area: Domaine 4
 title: Outils pour rendre un document accessible
 description: Certains outils existent pour faciliter la création de supports pédagogiques numérique qui sont accessibles et adaptés aux différents besoins des élèves. Des détails dans cette vidéo !
 videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/71d601ca-6f19-4f7b-8904-dc074e4bfb7f
-videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/71d601ca-6f19-4f7b-8904-dc074e4bfb7f-1080-fragmented.mp4
+videoDownloadHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/71d601ca-6f19-4f7b-8904-dc074e4bfb7f-1080-fragmented.mp4
 ---
 
 ## Transcription

--- a/content/edu/partager-et-diffuser-sa-veille-informationnelle.md
+++ b/content/edu/partager-et-diffuser-sa-veille-informationnelle.md
@@ -3,7 +3,7 @@ area: Domaine 1
 title: Partager et diffuser sa veille informationnelle
 description: Une fois que l'on a structuré sa veille informationnelle, on peut avoir envie de la partager à ses collègues et de la diffuser à des membres de la communauté éducative. Par où commencer ? Réponse dans cette vidéo.
 videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/be916f45-3257-477f-a060-10fb46564e83
-videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/be916f45-3257-477f-a060-10fb46564e83-1080-fragmented.mp4
+videoDownloadHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/be916f45-3257-477f-a060-10fb46564e83-1080-fragmented.mp4
 ---
 
 ## Transcription

--- a/content/edu/reperer-une-copie-ayant-eu-recours-au-plagiat.md
+++ b/content/edu/reperer-une-copie-ayant-eu-recours-au-plagiat.md
@@ -3,7 +3,7 @@ area: Domaine 3
 title: Repérer une copie ayant eu recours au plagiat
 description: Un doute sur l'authenticité d'un travail rendu sous un format numérique ? Dans cette vidéo, quelques solutions pour estimer rapidement si un élève est auteur de plagiat et des pistes pour sensibiliser ses élèves à ce sujet !
 videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/4d4ee6cd-cc4d-4253-9269-979a89835099
-videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/4d4ee6cd-cc4d-4253-9269-979a89835099-1080-fragmented.mp4
+videoDownloadHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/4d4ee6cd-cc4d-4253-9269-979a89835099-1080-fragmented.mp4
 ---
 
 ## Transcription

--- a/content/edu/resoudre-des-problemes-simples-lies-aux-outils-numeriques.md
+++ b/content/edu/resoudre-des-problemes-simples-lies-aux-outils-numeriques.md
@@ -3,7 +3,7 @@ area: Domaine 5
 title: Résoudre des problèmes simples liés aux outils numériques
 description: En classe, on n'est malheuresement jamais à l'abri d'un pépin technique quand on utilise des outils numériques. Dans cette vidéo, vous trouverez des conseils pour les éviter et réagir en cas d'imprévu !
 videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/4d5da479-0fe2-4e63-befd-ad3082fed30f
-videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/4d5da479-0fe2-4e63-befd-ad3082fed30f-1080-fragmented.mp4
+videoDownloadHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/4d5da479-0fe2-4e63-befd-ad3082fed30f-1080-fragmented.mp4
 ---
 
 ## Transcription

--- a/content/edu/savoir-indexer-une-ressource-en-ligne-pour-la-partager.md
+++ b/content/edu/savoir-indexer-une-ressource-en-ligne-pour-la-partager.md
@@ -3,7 +3,7 @@ area: Domaine 2
 title: Savoir indexer une ressource en ligne pour la partager
 description: "Une étape indispensable pour permettre à des collègues de trouver une ressource pédagogique géniale que l'on a partagée en ligne : l'indexation ! Toutes les explications dans cette vidéo."
 videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/3ad05af3-1ed3-4db7-8944-ff1286ed0d68
-videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/3ad05af3-1ed3-4db7-8944-ff1286ed0d68-1080-fragmented.mp4
+videoDownloadHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/3ad05af3-1ed3-4db7-8944-ff1286ed0d68-1080-fragmented.mp4
 ---
 
 ## Transcription

--- a/content/edu/scenariser-une-capsule-video.md
+++ b/content/edu/scenariser-une-capsule-video.md
@@ -3,7 +3,7 @@ area: Domaine 3
 title: Scénariser une capsule vidéo
 description: Avant de se lancer dans la captation vidéo, l'étape de scénarisation peut s'avérer précieuse pour créer une capsule dynamique et synthétique.
 videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/e4c4a8af-4f7d-42db-ac6e-cc1ab09714e5
-videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/e4c4a8af-4f7d-42db-ac6e-cc1ab09714e5-1080-fragmented.mp4
+videoDownloadHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/e4c4a8af-4f7d-42db-ac6e-cc1ab09714e5-1080-fragmented.mp4
 ---
 
 ## Transcription

--- a/content/edu/se-connecter-a-sa-messagerie-academique.md
+++ b/content/edu/se-connecter-a-sa-messagerie-academique.md
@@ -3,7 +3,7 @@ area: Domaine 1
 title: Se connecter à sa messagerie académique
 description: Avec cette vidéo, votre messagerie académique n'aura (quasiment) plus de secret pour vous !
 videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/09090670-0b40-478d-86b7-383451e602e8
-videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/09090670-0b40-478d-86b7-383451e602e8-1080-fragmented.mp4
+videoDownloadHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/09090670-0b40-478d-86b7-383451e602e8-1080-fragmented.mp4
 ---
 
 ## Transcription

--- a/content/edu/sites-ressources-pour-l-ecole-inclusive.md
+++ b/content/edu/sites-ressources-pour-l-ecole-inclusive.md
@@ -3,7 +3,7 @@ area: Domaine 4
 title: Sites ressources pour l'École inclusive
 description: Pour prendre en compte les besoins particuliers ou les handicaps de ses élèves, il existe certains sites de référence qui peuvent aider les enseignants à mieux les comprendre et les accompagner.
 videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/2e8aadf8-45d5-4b1b-b8f6-b232f8fb3792
-videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/2e8aadf8-45d5-4b1b-b8f6-b232f8fb3792-1080-fragmented.mp4
+videoDownloadHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/2e8aadf8-45d5-4b1b-b8f6-b232f8fb3792-1080-fragmented.mp4
 ---
 
 ## Transcription

--- a/content/edu/suivre-les-avancees-de-la-recherche-sur-le-numerique-educatif.md
+++ b/content/edu/suivre-les-avancees-de-la-recherche-sur-le-numerique-educatif.md
@@ -3,7 +3,7 @@ area: Domaine 1
 title: Suivre les avancées de la recherche sur le numérique éducatif
 description: De nombreux chercheurs en sciences de l'éducation s'intéressent à l'usage du numérique en pédagogie. Les résultats de ces recherches permettent d'interroger et de prendre du recul sur ces usages. Comment suivre en tant qu'enseignant les avancées des travaux de recherche à ce sujet ?
 videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/4b76c54c-4ea7-46f7-9643-2617f7ba8eb1
-videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/4b76c54c-4ea7-46f7-9643-2617f7ba8eb1-1080-fragmented.mp4
+videoDownloadHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/4b76c54c-4ea7-46f7-9643-2617f7ba8eb1-1080-fragmented.mp4
 ---
 
 ## Transcription

--- a/content/edu/trouver-et-proposer-des-ressources-pour-le-site-prim-a-bord.md
+++ b/content/edu/trouver-et-proposer-des-ressources-pour-le-site-prim-a-bord.md
@@ -3,7 +3,7 @@ area: Domaine 2
 title: Trouver et proposer des ressources pour le site Prim à bord
 description: Si vous êtes enseignant du premier degré et que vous cherchez souvent des ressources pédagogiques sur internet, le site Prim à bord et cette vidéo explicative sont fait pour vous !
 videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/4c0e95cc-9e00-4193-af2f-7f7f341eceee
-videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/4c0e95cc-9e00-4193-af2f-7f7f341eceee-1080-fragmented.mp4
+videoDownloadHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/4c0e95cc-9e00-4193-af2f-7f7f341eceee-1080-fragmented.mp4
 ---
 
 ## Transcription

--- a/content/edu/utiliser-des-capsules-video-en-classe.md
+++ b/content/edu/utiliser-des-capsules-video-en-classe.md
@@ -3,7 +3,7 @@ area: Domaine 3
 title: Utiliser des capsules vidéo en classe
 description: Les capsules vidéos peuvent être un moyen de varier le type de ressources pédagogiques proposées à ses élèves. Comment s'en saisir et les utiliser en classe ?
 videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/68d966e7-76f4-4ff2-8544-ab9a86c1b815
-videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/68d966e7-76f4-4ff2-8544-ab9a86c1b815-1080-fragmented.mp4
+videoDownloadHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/68d966e7-76f4-4ff2-8544-ab9a86c1b815-1080-fragmented.mp4
 ---
 
 ## Transcription

--- a/content/edu/utiliser-les-outils-de-quiz-en-ligne-pour-diversifier-son-evaluation.md
+++ b/content/edu/utiliser-les-outils-de-quiz-en-ligne-pour-diversifier-son-evaluation.md
@@ -3,7 +3,7 @@ area: Domaine 3
 title: Utiliser les outils de quiz en ligne pour diversifier son évaluation
 description: 'Les quiz en ligne peuvent présenter certains avantages par rapport à des quiz débranchés : rétroaction, analyse synthétique de résultats, ... Plus de détails dans cette vidéo !'
 videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/3a19ecea-b46e-479b-9bcc-7268b744534e
-videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/3a19ecea-b46e-479b-9bcc-7268b744534e-1080-fragmented.mp4
+videoDownloadHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/3a19ecea-b46e-479b-9bcc-7268b744534e-1080-fragmented.mp4
 ---
 
 ## Transcription

--- a/content/edu/utiliser-les-reseaux-sociaux-comme-outils-de-veille-informationnelle.md
+++ b/content/edu/utiliser-les-reseaux-sociaux-comme-outils-de-veille-informationnelle.md
@@ -3,5 +3,5 @@ area: Domaine 1
 title: Utiliser les réseaux sociaux comme outils de veille informationnelle
 description: Dans cette vidéo, quelques pistes pour outiller sa veille à l'aide des réseaux sociaux.
 videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/a7145305-857e-4973-a738-c3a582b3cdf1
-videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/a7145305-857e-4973-a738-c3a582b3cdf1-1080-fragmented.mp4
+videoDownloadHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/a7145305-857e-4973-a738-c3a582b3cdf1-1080-fragmented.mp4
 ---

--- a/content/edu/utiliser-un-tni.md
+++ b/content/edu/utiliser-un-tni.md
@@ -3,7 +3,7 @@ area: Domaine 3
 title: Utiliser un TBI/TNI
 description: "Au programme de cette vidéo : explication sur le fonctionnement d'un tableau numérique interactif et quelques exemples de fonctionnalités."
 videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/a948661e-2ee2-4250-9ee9-04dfde2d8753
-videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/a948661e-2ee2-4250-9ee9-04dfde2d8753-1080-fragmented.mp4
+videoDownloadHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/a948661e-2ee2-4250-9ee9-04dfde2d8753-1080-fragmented.mp4
 ---
 
 ## Transcription

--- a/content/edu/utiliser-une-illustration-en-licence-libre.md
+++ b/content/edu/utiliser-une-illustration-en-licence-libre.md
@@ -3,7 +3,7 @@ area: Domaine 2
 title: Utiliser une illustration en licence libre
 description: Peut-on utiliser librement n'importe quelle illustration pour ses supports de cours ? Qu’est-ce qu’une illustration en licence libre et pourquoi privilégier leur utilisation ? Éléments de réponse dans cette vidéo !
 videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/3a09576d-cf6c-4d3d-a920-e7f537f1a9ff
-videoDLHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/3a09576d-cf6c-4d3d-a920-e7f537f1a9ff-1080-fragmented.mp4
+videoDownloadHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/3a09576d-cf6c-4d3d-a920-e7f537f1a9ff-1080-fragmented.mp4
 ---
 
 ## Transcription

--- a/pages/edu/[slug].vue
+++ b/pages/edu/[slug].vue
@@ -5,7 +5,7 @@
       :title="page.title"
       :description="page.description"
       :video-embed-src="videoEmbedSrc"
-      :video-dl-href="page.videoDLHref"
+      :video-download-href="page.videoDownloadHref"
     />
   </article>
 </template>

--- a/pages/edu/[slug].vue
+++ b/pages/edu/[slug].vue
@@ -6,8 +6,6 @@
       :description="page.description"
       :video-embed-src="videoEmbedSrc"
       :video-dl-href="page.videoDLHref"
-      :fiche-pdf-href="page.fichePdfHref"
-      :transcript-pdf-href="page.transcriptPdfHref"
     />
   </article>
 </template>

--- a/tests/unit/verify-edu-content.test.js
+++ b/tests/unit/verify-edu-content.test.js
@@ -82,8 +82,7 @@ describe('Verification du contenu dans le dossier `content/edu`', function () {
           'description',
           'videoEmbedSrc',
           'videoDLHref',
-          'fichePdfHref',
-          'transcriptPdfHref',
+
         ];
         try {
           expect(acceptedFields).toEqual(
@@ -119,32 +118,6 @@ describe('Verification du contenu dans le dossier `content/edu`', function () {
         } catch {
           throw new Error(
             `Le format du lien "videoDLHref" est invalide (format attendu : "https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/{ID_VIDEO}.mp4", valeur reçue : "${tutoFileMetadata.videoDLHref}")`
-          );
-        }
-      });
-
-      it('le champ `fichePdfHref` doit avoir un format précis (si présent)', function () {
-        if (!tutoFileMetadata.fichePdfHref) return;
-        try {
-          expect(tutoFileMetadata.fichePdfHref).toMatch(
-            /^https:\/\/dl\.pix\.fr\/tutoFileContents\/(\w|-)+\.pdf$/
-          );
-        } catch {
-          throw new Error(
-            `Le format du lien "fichePdfHref" est invalide (format attendu : "https://dl.pix.fr/tutoFileContents/{ID_TUTOFileContent}.pdf", valeur reçue : "${tutoFileMetadata.fichePdfHref}")`
-          );
-        }
-      });
-
-      it('le champ `transcriptPdfHref` doit avoir un format précis (si présent)', function () {
-        if (!tutoFileMetadata.transcriptPdfHref) return;
-        try {
-          expect(tutoFileMetadata.transcriptPdfHref).toMatch(
-            /^https:\/\/dl\.pix\.fr\/tutoFileContents\/(\w|-)+\.pdf$/
-          );
-        } catch {
-          throw new Error(
-            `Le format du lien "transcriptPdfHref" est invalide (format attendu : "https://dl.pix.fr/tutoFileContents/{ID_TUTOFileContent}.pdf", valeur reçue : "${tutoFileMetadata.fichePdfHref}")`
           );
         }
       });

--- a/tests/unit/verify-edu-content.test.js
+++ b/tests/unit/verify-edu-content.test.js
@@ -81,7 +81,7 @@ describe('Verification du contenu dans le dossier `content/edu`', function () {
           'title',
           'description',
           'videoEmbedSrc',
-          'videoDLHref',
+          'videoDownloadHref',
 
         ];
         try {
@@ -109,15 +109,15 @@ describe('Verification du contenu dans le dossier `content/edu`', function () {
         }
       });
 
-      it('le champ `videoDLHref` doit avoir un format précis (si présent)', function () {
-        if (!tutoFileMetadata.videoDLHref) return;
+      it('le champ `videoDownloadHref` doit avoir un format précis (si présent)', function () {
+        if (!tutoFileMetadata.videoDownloadHref) return;
         try {
-          expect(tutoFileMetadata.videoDLHref).toMatch(
+          expect(tutoFileMetadata.videoDownloadHref).toMatch(
             /^https:\/\/tube\.reseau-canope\.fr\/download\/streaming-playlists\/hls\/videos\/(\w|-)+\.mp4$/
           );
         } catch {
           throw new Error(
-            `Le format du lien "videoDLHref" est invalide (format attendu : "https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/{ID_VIDEO}.mp4", valeur reçue : "${tutoFileMetadata.videoDLHref}")`
+            `Le format du lien "videoDownloadHref" est invalide (format attendu : "https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/{ID_VIDEO}.mp4", valeur reçue : "${tutoFileMetadata.videoDownloadHref}")`
           );
         }
       });


### PR DESCRIPTION
## BREAKING CHANGE
On supprime le support de `fichePdfHref` et `transcriptPdfHref` qui ont été développés différemment. `videoDlHref` devient `videoDownloadHref` pour plus de clareté.

## Problème
Pour le tracking Matomo on est pour le moment lié au contenu textuel du bouton, donc si ce texte change on perd le tracking.

## :robot: Proposition
Ajouter des `id` sur les boutons pour les utiliser comme filtre.

## :rainbow: Remarques
Un peu de nettoyage en plus

## :100: Pour tester
Vérifier que les 2 boutons d'action sur les pages de tuto ont bien des `id` différents.
