### PR TITLE
[BUGFIX] Corriger l'ordre des domaines sur /edu 

### DIFF
--- a/pages/edu/index.vue
+++ b/pages/edu/index.vue
@@ -5,7 +5,7 @@ definePageMeta({ layout: 'edu' })
 useHead({ title: 'Accueil' })
 
 const areas = getAreas()
-const tutos = await queryContent('edu').sort({ area: 1, title: 1 }).find()
+const tutos = await queryContent('edu').sort({ title: 1, area: 1 }).find()
 
 const tutosGroupedByArea = tutos.reduce((acc, tuto) => {
   if (!acc[tuto.area])


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, l'ordre des domaines n'est pas correct

## :robot: Proposition
Il faut d'abord trier par titre, puis ensuite par domaine, si nous faisons l'inverse le trie par titre l'emporte

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Se rendre sur la page /edu
