### PR TITLE
[FEATURE] Permettre d'avoir `Webinaires` comme domaine de tutoriel (PIX-8618)

### DIFF
--- a/services/get-areas.ts
+++ b/services/get-areas.ts
@@ -9,5 +9,6 @@ export default function getAreas() {
       'Inclure et rendre accessible, différencier et engager les apprenants',
     'Domaine 5':
       'Développer, évaluer et certifier les compétences numériques des apprenants',
+    'Webinaires': 'Une série de webinaires produits par Réseau Canopé, en partenariat avec Pix pour se former et actualiser ses compétences numériques professionnelles',
   }
 }


### PR DESCRIPTION
## :unicorn: Problème
Il est restrictif d'avoir uniquement le choix entre les 5 domaines de Pix, alors que certains webinaires sont transverses.

## :robot: Proposition
Ajouter une section `Webinaire`

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
