### PR TITLE
[FEATURE] Permettre le clic droit sur les vidéos Plyr (PIX-9157)

### DIFF
--- a/assets/scss/globals.scss
+++ b/assets/scss/globals.scss
@@ -45,4 +45,9 @@ p, li {
 
 .plyr {
   --plyr-color-main: #{$blue-50};
+
+  /* Allow to interact with the `video` element */
+  &__poster {
+    display: none;
+  }
 }

--- a/components/PixVideoPlayer.vue
+++ b/components/PixVideoPlayer.vue
@@ -19,7 +19,7 @@ defineProps({
 const video = ref(null)
 onMounted(() => {
   // eslint-disable-next-line no-new
-  new Plyr(video.value, { hideControls: false })
+  new Plyr(video.value, { hideControls: false, disableContextMenu: false })
 })
 </script>
 


### PR DESCRIPTION
## :unicorn: Problème
Le clic droit est interdit sur les vidéos Plyr.

## :robot: Proposition
L'activer pour permettre l'utilisation fonctionnalités natives des navigateurs.

## :rainbow: Remarques
La doc du paramètre utilisé :
> Disable right click menu on video to help as very primitive obfuscation to prevent downloads of content.

## :100: Pour tester
Accéder à `<RA>/mednum/interagir-avec-une-visualisation`
