### PR TITLE
[FEATURE] Enleve les logos de Minister d'Edu dans les pages Mednum

### DIFF
--- a/layouts/mednum.vue
+++ b/layouts/mednum.vue
@@ -1,0 +1,77 @@
+<script setup>
+useHead({ titleTemplate: '%s - Mednum' })
+</script>
+
+<template>
+  <div
+    id="app"
+    class="app-viewport"
+  >
+    <PixHeader :hide-actions="false" />
+
+    <main
+      role="main"
+      class="main-container"
+    >
+      <img
+        src="~/assets/images/pix-logo.svg"
+        class="logo"
+        alt="Pix"
+      >
+
+      <slot />
+    </main>
+  </div>
+</template>
+
+<style lang="scss">
+#app {
+  min-height: 100vh;
+  font-family: $font-roboto;
+  background-color: $background-light;
+}
+
+.main-container {
+  padding: 4rem 1rem;
+  max-width: 980px;
+  margin: 0 auto;
+}
+
+.partners {
+  margin-top: 48px;
+  padding: 32px 0;
+  border-top: 1px solid $pix-neutral-20;
+  border-bottom: 1px solid $pix-neutral-20;
+
+  img {
+    display: block;
+    width: 450px;
+    max-width: 100%;
+    margin: 0 auto;
+  }
+}
+
+.logo {
+  display: none;
+  width: 100px;
+}
+
+@media print {
+  #app {
+    background-color: $pix-neutral-0;
+  }
+
+  .main-container {
+    padding: 0;
+  }
+
+  // Nous mettons le !important pour éviter la surcharge du style par celui de la page qui est appliqué ensuite.
+  .main-header, .tuto__description, .tuto__video, .tuto__actions {
+    display: none !important;
+  }
+
+  .logo {
+    display: block;
+  }
+}
+</style>

--- a/pages/mednum/[slug].vue
+++ b/pages/mednum/[slug].vue
@@ -1,7 +1,7 @@
 <script setup>
 import { ref } from 'vue'
 
-definePageMeta({ layout: 'edu' })
+definePageMeta({ layout: 'mednum' })
 
 const page = ref(null)
 
@@ -76,7 +76,7 @@ function downloadTranscript() {
         :id="slug"
         :pdf-file-path="page.pdfFilePath"
       />
-</PixTutorial>
+    </PixTutorial>
   </article>
 </template>
 

--- a/pages/mednum/index.vue
+++ b/pages/mednum/index.vue
@@ -1,5 +1,5 @@
 <script setup>
-definePageMeta({ layout: 'edu' })
+definePageMeta({ layout: 'mednum' })
 useHead({ title: 'Accueil' })
 
 const tutos = await queryContent('mednum').sort({ title: 1 }).find()


### PR DESCRIPTION
## :unicorn: Problème
Les pages Mednum affiche dans le footer les logos qui sont pas correct

## :robot: Proposition
Creer un nouveau layout pour Mednum et enleve les logos qui sont pas pertinent

## :rainbow: Remarques
Nous allons ajouter les logos qui sont pertinent quand nous les recevrons

## :100: Pour tester
Accéder à la page `Tutos MedNum`
Choissir un tuto et verifier qu'on ne voit pas les logos de Minister l'Education
