### PR TITLE
[FEATURE] Ajout de la traduction française pour le player vidéo de MedNum (PIX-9226)

### DIFF
--- a/assets/translation/player_fr.js
+++ b/assets/translation/player_fr.js
@@ -1,0 +1,50 @@
+// ==========================================================================
+// Plyr French translation
+// ==========================================================================
+
+const i18n = {
+  restart: 'Relancer',
+  rewind: 'Rembobiner {seektime}s',
+  play: 'Jouer',
+  pause: 'Pause',
+  fastForward: 'Avancer {seektime}s',
+  seek: 'Chercher',
+  seekLabel: '{currentTime} sur {duration}',
+  played: 'Lu',
+  buffered: 'En mémoire',
+  currentTime: 'Temps actuel',
+  duration: 'Durée',
+  volume: 'Volume',
+  mute: 'Silence',
+  unmute: 'Réactiver le son',
+  enableCaptions: 'Activer les sous-titres',
+  disableCaptions: 'Désactiver les sous-titres',
+  download: 'Télécharger',
+  enterFullscreen: 'Entrer dans le mode plein écran',
+  exitFullscreen: 'Sortir du mode plein écran',
+  frameTitle: 'Lecteur pour {title}',
+  captions: 'Sous-titres',
+  settings: 'Options',
+  menuBack: 'Revenir au menu précédent',
+  speed: 'Vitesse',
+  normal: 'Normal',
+  quality: 'Qualité',
+  loop: 'Boucle',
+  start: 'Début',
+  end: 'Fin',
+  all: 'Toutes',
+  reset: 'Relancer',
+  disabled: 'Désactivé',
+  enabled: 'Activé',
+  advertisement: 'Publicité',
+  qualityBadge: {
+    480: 'SD',
+    576: 'SD',
+    720: 'HD',
+    1080: 'HD',
+    1440: 'HD',
+    2160: '4K',
+  },
+}
+
+export default i18n

--- a/components/PixVideoPlayer.vue
+++ b/components/PixVideoPlayer.vue
@@ -1,4 +1,5 @@
 <script setup>
+import player_fr from 'assets/translation/player_fr'
 import Plyr from 'plyr'
 
 defineProps({
@@ -19,7 +20,7 @@ defineProps({
 const video = ref(null)
 onMounted(() => {
   // eslint-disable-next-line no-new
-  new Plyr(video.value, { hideControls: false, disableContextMenu: false })
+  new Plyr(video.value, { hideControls: false, disableContextMenu: false, i18n: player_fr })
 })
 </script>
 
@@ -37,7 +38,7 @@ onMounted(() => {
     >
     <track
       kind="captions"
-      label="Sous titres"
+      label="Français"
       :src="captionVtt"
       srclang="fr"
       default


### PR DESCRIPTION
## :unicorn: Problème
Par défaut le player vidéo plyr utilisé pour MedNum est en anglais et ne possède pas de traduction française intégrée.

## :robot: Proposition
Intégrer à la main la traduction française (à compléter avec Anaïs)
> ⚠️ Pour les devs, l'endroit où j'ai rangé le fichier de trad est évidemment à challenger :)

## :rainbow: Remarques
[Discussion sur le sujet dans le repo de plyr](https://github.com/sampotts/plyr/issues/1261)

[Commit sur le repo de plyr avec les locales anglais](https://github.com/filips123/plyr/commit/ed4af258de7dc7ecc5791ade58d28f4f1e55399c)

## :100: Pour tester
Ouvrir par exemple [cette page](https://tutos.integration.pix.fr/mednum/interagir-avec-une-visualisation) et vérifier les traductions dans l'option de la vidéo (engrenage en bas à droite du player)
