### PR TITLE
[BUGFIX] Page MedNum - modifier le label du CTA pour les PDF (PIX-9300)

### DIFF
--- a/components/PixPdf.vue
+++ b/components/PixPdf.vue
@@ -26,7 +26,7 @@ defineProps({
           target="_blank"
           rel="noopener noreferrer"
         >
-          Télécharger le pdf
+          Ouvrir le PDF
         </PixButtonLink>
       </li>
     </ul>


### PR DESCRIPTION
## :unicorn: Problème
Dans les tutos PDF de la MedNum, il faut modifier le CTA "Télécharger le pdf" en "Ouvrir le PDF".

## :robot: Proposition
Modification en dur du texte du bouton

## :rainbow: Remarques
> _nope_

## :100: Pour tester
Checker visuellement sur `mednum/icone-de-la-messagerie` par exemple.
