### PR TITLE
[BUGFIX] Coquille à corriger dans la description de l'accueil de Mednum (PIX-9305)

### DIFF
--- a/pages/mednum/index.vue
+++ b/pages/mednum/index.vue
@@ -11,7 +11,7 @@ const tutos = await queryContent('mednum').sort({ title: 1 }).find()
       Tutoriels produits par la MedNum pour Pix
     </h1>
 
-    <p class="pix-body-l header__description">Améliorez vos compétences sur la messagerie électronique, l'identité numérique, la datavisualisation et l'impact environnement du numérique grâce à ces tutoriels vidéos ou infographies, produits par la MedNum pour Pix dans le cadre d'un projet Proof of Concept (POC).</p>
+    <p class="pix-body-l header__description">Améliorez vos compétences sur la messagerie électronique, l'identité numérique, la datavisualisation et l'impact environnemental du numérique grâce à ces tutoriels vidéos ou infographies, produits par la MedNum pour Pix dans le cadre d'un projet Proof of Concept (POC).</p>
 
     <section>
       <ul class="tutorial-list">


### PR DESCRIPTION
## :unicorn: Problème
Une coquille s'est glissée dans le texte de la description.

## :robot: Proposition
Petite correction en dur

## :rainbow: Remarques
> _nope_

## :100: Pour tester
Correction visible ici `/mednum`
