### PR TITLE
[BUGFIX] Cache le lecteur vidéo de la MedNum dans les styles d'impression (PIX-9460)

### DIFF
--- a/assets/scss/globals.scss
+++ b/assets/scss/globals.scss
@@ -20,6 +20,15 @@ p, li {
   @extend %pix-body-m;
 }
 
+.plyr {
+  --plyr-color-main: #{$blue-50};
+
+  /* Allow to interact with the `video` element */
+  &__poster {
+    display: none;
+  }
+}
+
 // We cannot extend placeholders when using a media query.
 // We chose to copy typography styles manually.
 @media print {
@@ -40,14 +49,5 @@ p, li {
     line-height: 1.5;
     letter-spacing: 0.02em;
     text-align: justify;
-  }
-}
-
-.plyr {
-  --plyr-color-main: #{$blue-50};
-
-  /* Allow to interact with the `video` element */
-  &__poster {
-    display: none;
   }
 }

--- a/layouts/mednum.vue
+++ b/layouts/mednum.vue
@@ -66,7 +66,7 @@ useHead({ titleTemplate: '%s - Mednum' })
   }
 
   // Nous mettons le !important pour éviter la surcharge du style par celui de la page qui est appliqué ensuite.
-  .main-header, .tuto__description, .tuto__video, .tuto__actions {
+  .main-header, .tuto__description, .plyr, .tuto__actions {
     display: none !important;
   }
 


### PR DESCRIPTION
## :unicorn: Problème
Le lecteur vidéo de la MedNum est affiché lors de l'impression, et donc du clic sur le bouton "Télécharger la transcription".

## :robot: Proposition
Le supprimer.

## :rainbow: Remarques
Ajouter la classe `.tuto__video` sur `PixVideoPlayer` n'est pas suffisant car Plyr ajoute des éléments qui prennent de l'espace autour de la balise video. D'où l'usage de la classe `.plyr` directement.

## :100: Pour tester
Vérifier que le lecteur est caché à l'impression, et visible à l'usage habituel.
