### PR TITLE
[BUGFIX] Centrer le lecteur vidéo MedNum en plein écran sur mobile (PIX-9469)

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "3.7.0",
   "scripts": {
     "dev": "nuxt dev",
+    "dev:mobile": "nuxt dev --host",
     "build": "nuxt generate",
     "start": "nuxt start",
     "lint": "eslint --ext .js,.vue --ignore-path .gitignore .",

--- a/pages/mednum/[slug].vue
+++ b/pages/mednum/[slug].vue
@@ -85,6 +85,10 @@ function downloadTranscript() {
   margin: 2rem 0 1rem;
 }
 
+.plyr--fullscreen-fallback {
+  margin: 0;
+}
+
 .tuto__actions {
     display: flex;
     flex-wrap: wrap;


### PR DESCRIPTION
## :unicorn: Problème
Le lecteur vidéo en plein écran n'est pas centré sur la page en mobile et déborde donc il est impossible d'utiliser les commandes pour mettre en pause ou quitter le mode plein écran par exemple.

## :robot: Proposition
Le recentrer.

## :rainbow: Remarques
J'ai ajouté un script npm pour lancer le mode dev sur son réseau local, pour pouvoir y accéder depuis un smartphone par exemple.

## :100: Pour tester
Accéder à l'intégration sur un mobile et comparer le résultat avec cette RA.
