### PR TITLE
[FEATURE] Renommer des boutons d'action (PIX-9950) (PIX-9166)

### DIFF
--- a/components/PixPdf.vue
+++ b/components/PixPdf.vue
@@ -21,7 +21,7 @@ defineProps({
         class="pdf-actions__item"
       >
         <PixButtonLink
-          id="download-pdf"
+          id="open-pdf"
           :href="pdfFilePath"
           target="_blank"
           rel="noopener noreferrer"

--- a/pages/edu/[slug].vue
+++ b/pages/edu/[slug].vue
@@ -30,7 +30,7 @@ useHead({
   ],
 })
 
-function downloadTranscript() {
+function printTranscript() {
   window.print()
 }
 </script>
@@ -68,10 +68,10 @@ function downloadTranscript() {
           class="tuto-actions__item"
         >
           <PixButton
-            id="download-transcript"
-            :action="downloadTranscript"
+            id="print-transcript"
+            :action="printTranscript"
           >
-            Télécharger la transcription
+            Imprimer la transcription
           </PixButton>
         </li>
       </ul>

--- a/pages/mednum/[slug].vue
+++ b/pages/mednum/[slug].vue
@@ -25,7 +25,7 @@ useHead({
   ],
 })
 
-function downloadTranscript() {
+function printTranscript() {
   window.print()
 }
 </script>
@@ -64,10 +64,10 @@ function downloadTranscript() {
           class="tuto-actions__item"
         >
           <PixButton
-            id="download-transcript"
-            :action="downloadTranscript"
+            id="print-transcript"
+            :action="printTranscript"
           >
-            Télécharger la transcription
+            Imprimer la transcription
           </PixButton>
         </li>
       </ul>


### PR DESCRIPTION
## :unicorn: Problème
Le nom du bouton d'action "Télécharger la transcription" porte à confusion.

## :robot: Proposition
Le renommer pour clarifier son intention.

Également une mini reprise technique sur le bouton d'ouverture du PDF.

## :rainbow: Remarques
RAS

## :100: Pour tester
Vérifier que :
- les boutons d'impression de transcription fonctionnent toujours (+Edu et mednum).
- le bouton pour ouvrir le PDF doit toujours fonctionner.
