### PR TITLE
[FEATURE] Ajouter des tutos vidéos pour les sixièmes (PIX-9958)

### DIFF
--- a/components/PixVideoPlayer.vue
+++ b/components/PixVideoPlayer.vue
@@ -13,7 +13,7 @@ defineProps({
   },
   captionVtt: {
     type: String,
-    required: true,
+    // ToDo: should be required when sixieme transcriptions are available
   },
 })
 
@@ -36,7 +36,9 @@ onMounted(() => {
       :src="sourceMp4"
       type="video/mp4"
     >
+    <!-- ToDo: v-if can be deleted when sixieme transcriptions are available -->
     <track
+      v-if="captionVtt"
       kind="captions"
       label="Français"
       :src="captionVtt"

--- a/content/sixieme/comment-reconnaitre-des-situations-de-cyberharcelement-et-comment-y-faire-face.md
+++ b/content/sixieme/comment-reconnaitre-des-situations-de-cyberharcelement-et-comment-y-faire-face.md
@@ -1,0 +1,16 @@
+---
+title: Comment reconnaître des situations de cyberharcèlement et comment y faire face ?
+description:
+videoEmbedSrc: https://videos.pix.fr/tutos/sixieme/PIX_Cyberharcelement_v08_231109.mp4
+captionFilePath:
+---
+
+## Transcription
+
+Lorsque quelqu'un est agressé sur les réseaux sociaux ou en ligne, de manière intentionnelle et répétée, par une personne ou un groupe de personnes, il s'agit de cyberharcèlement. Cela provoque chez la victime un isolement qui l'empêche de pouvoir se défendre.
+
+Le cyberharcèlement cela peut être des moqueries, des insultes, des menaces, des rumeurs diffusées via des messageries instantanées, des forums, des tchats, des courriers électroniques, la publication d'une photo ou d'une vidéo gênante ou humiliante. Mais aussi la création d'un groupe, d'une page sur les réseaux sociaux ou encore le piratage d'un compte. Le cyberharcèlement laisse des traces numériques.
+
+Si une personne de votre entourage change brutalement de comportement ou s'isole cela peut être un signe de cyberharcèlement. De même, si elle montre des accès de colère inhabituels ou une perte d'appétit.
+
+Pour l'aider le mieux est de pouvoir parler avec elle, pour qu'elle puisse s'exprimer, confier ses émotions, mettre des mots sur la situation et sortir de son isolement. Si cela n'est pas possible, vous pouvez aussi prévenir un adulte de confiance. Être témoin de cyberharcèlement est un rôle primordial, vous vous devez d'agir. Le meilleur moyen de lutter contre le cyberharcèlement est de le faire savoir. Pour avoir de l'aide ou des conseils contactez le 3018 par tchat ou via l'application. C'est anonyme et gratuit.

--- a/layouts/sixieme.vue
+++ b/layouts/sixieme.vue
@@ -1,0 +1,77 @@
+<script setup>
+useHead({ titleTemplate: '%s - Sixième' })
+</script>
+
+<template>
+  <div
+    id="app"
+    class="app-viewport"
+  >
+    <PixHeader :hide-actions="false" />
+
+    <main
+      role="main"
+      class="main-container"
+    >
+      <img
+        src="~/assets/images/pix-logo.svg"
+        class="logo"
+        alt="Pix"
+      >
+
+      <slot />
+    </main>
+  </div>
+</template>
+
+<style lang="scss">
+#app {
+  min-height: 100vh;
+  font-family: $font-roboto;
+  background-color: $background-light;
+}
+
+.main-container {
+  padding: 4rem 1rem;
+  max-width: 980px;
+  margin: 0 auto;
+}
+
+.partners {
+  margin-top: 48px;
+  padding: 32px 0;
+  border-top: 1px solid $pix-neutral-20;
+  border-bottom: 1px solid $pix-neutral-20;
+
+  img {
+    display: block;
+    width: 450px;
+    max-width: 100%;
+    margin: 0 auto;
+  }
+}
+
+.logo {
+  display: none;
+  width: 100px;
+}
+
+@media print {
+  #app {
+    background-color: $pix-neutral-0;
+  }
+
+  .main-container {
+    padding: 0;
+  }
+
+  // Nous mettons le !important pour éviter la surcharge du style par celui de la page qui est appliqué ensuite.
+  .main-header, .tuto__description, .plyr, .tuto__actions {
+    display: none !important;
+  }
+
+  .logo {
+    display: block;
+  }
+}
+</style>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -15,5 +15,10 @@ useHead({ title: 'Accueil' })
         Tutos Mednum
       </nuxt-link>
     </h2>
+    <h2>
+      <nuxt-link to="sixieme">
+        Tutos Sixième
+      </nuxt-link>
+    </h2>
   </div>
 </template>

--- a/pages/sixieme/[slug].vue
+++ b/pages/sixieme/[slug].vue
@@ -1,0 +1,94 @@
+<script setup>
+import { ref } from 'vue'
+
+definePageMeta({ layout: 'sixieme' })
+
+const page = ref(null)
+
+const slug = useRoute().params.slug || 'index'
+
+page.value = await queryContent(`/sixieme/${slug}`)
+  .findOne()
+  .catch((err) => {
+    console.error(err)
+    useError({ statusCode: 404, message: 'Ce tuto n\'existe pas.' })
+  })
+
+useHead({
+  title: page.value.title,
+  meta: [
+    {
+      hid: 'description',
+      name: 'description',
+      content: page.value.description,
+    },
+  ],
+})
+
+function printTranscript() {
+  window.print()
+}
+</script>
+
+<template>
+  <article>
+    <PixTutorial
+      :page="page"
+      :title="page.title"
+      :description="page.description || ''"
+    >
+      <PixVideoPlayer
+        v-if="page.videoEmbedSrc"
+        :id="slug"
+        :source-mp4="page.videoEmbedSrc"
+      />
+
+      <ul
+        v-if="page.videoEmbedSrc"
+        class="tuto__actions"
+      >
+        <li
+          class="tuto-actions__item"
+        >
+          <PixButtonLink
+            id="download-video"
+            :href="page.videoEmbedSrc"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Télécharger la video
+          </PixButtonLink>
+        </li>
+        <li
+          class="tuto-actions__item"
+        >
+          <PixButton
+            id="print-transcript"
+            :action="printTranscript"
+          >
+            Imprimer la transcription
+          </PixButton>
+        </li>
+      </ul>
+    </PixTutorial>
+  </article>
+</template>
+
+<style lang="scss">
+.plyr {
+  margin: 2rem 0 1rem;
+}
+
+.plyr--fullscreen-fallback {
+  margin: 0;
+}
+
+.tuto__actions {
+    display: flex;
+    flex-wrap: wrap;
+    list-style-type: none;
+    gap: 1rem;
+    padding: 0;
+    margin: 0 0 2rem;
+  }
+</style>

--- a/pages/sixieme/index.vue
+++ b/pages/sixieme/index.vue
@@ -1,0 +1,89 @@
+<script setup>
+definePageMeta({ layout: 'sixieme' })
+useHead({ title: 'Accueil' })
+
+const tutos = await queryContent('sixieme').sort({ title: 1 }).find()
+</script>
+
+<template>
+  <div>
+    <h1 class="header__title">
+      Capsules vidéos de sensibilisation au numérique - attestation Pix en 6ème
+    </h1>
+
+    <p class="pix-body-l header__description">
+      Dans le cadre du déploiement de l’attestation de sensibilisation au numérique Pix et en vue d’accompagner au mieux les élèves dans cette démarche de sensibilisation, 6 capsules vidéo ont été réalisées par le ministère de l’Éducation nationale et de la Jeunesse, en partenariat avec la CNIL, cybermalveillance.gouv.fr, e-enfance et Pix.
+    </p>
+
+    <section>
+      <ul class="tutorial-list">
+        <li
+          v-for="tuto in tutos"
+          :key="tuto._id"
+          class="tutorial-list__item"
+        >
+          <nuxt-link :to="tuto._path">
+            <h3 class="pix-title-xs tuto-block">
+              {{ tuto.title }}
+            </h3>
+          </nuxt-link>
+        </li>
+      </ul>
+    </section>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+a {
+  text-decoration: none;
+  color: $black-90;
+}
+
+ul {
+  list-style: none;
+  padding-left: 0;
+}
+
+.header {
+  &__title {
+    margin-bottom: 8px;
+  }
+  &__description {
+    margin-bottom: 56px;
+    color: $pix-neutral-50;
+    font-weight: 500;
+  }
+}
+
+.area {
+  &__title {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    margin-top: 32px;
+    margin-bottom: 20px;
+  }
+  &__number {
+    color: $pix-neutral-50;
+  }
+}
+
+.tutorial-list {
+  margin-bottom: 40px;
+
+  &__item:not(:last-child) {
+    margin-bottom: 12px;
+  }
+}
+
+.tuto-block {
+  border-radius: 10px;
+  padding: 16px 24px;
+  background: $pix-neutral-0;
+  box-shadow: $box-shadow-xs;
+
+  &:hover {
+    color: $blue-hover;
+  }
+}
+</style>

--- a/tests/e2e/sixieme/content.spec.ts
+++ b/tests/e2e/sixieme/content.spec.ts
@@ -1,0 +1,19 @@
+import { expect, test } from '@playwright/test'
+
+test.describe('#sixieme content', () => {
+  test('should show correctly', async ({ page }) => {
+    // given
+    const pageToVisit = '/sixieme'
+
+    // when
+    await page.goto(pageToVisit)
+
+    // then
+    await expect
+      .soft(page.getByRole('heading', { name: 'Capsules vidéos de sensibilisation au numérique - attestation Pix en 6ème' }))
+      .toBeVisible()
+
+    for (const link of await page.getByRole('link').all())
+      await expect.soft(link).toBeVisible()
+  })
+})

--- a/tests/unit/verify-sixieme-content.test.js
+++ b/tests/unit/verify-sixieme-content.test.js
@@ -1,0 +1,109 @@
+import path from 'node:path'
+import fs from 'node:fs'
+import { beforeEach, describe, expect, it } from 'vitest'
+import parseMarkdownMetadata from '../../services/parse-markdown'
+
+describe('Verification du contenu dans le dossier `content/sixieme`', () => {
+  const contentPath = path.join(__dirname, '../../content/sixieme')
+  const dirContent = fs.readdirSync(contentPath)
+
+  dirContent.forEach((file) => {
+    let tutoFileMetadata = {}
+
+    beforeEach(() => {
+      try {
+        const markdown = fs.readFileSync(path.join(contentPath, file), 'utf8')
+        tutoFileMetadata = parseMarkdownMetadata(markdown)
+      }
+      catch {
+        throw new Error(`Le fichier ${file} n'a aucune metadonnée`)
+      }
+    })
+
+    describe(`Le fichier ${file}`, () => {
+      it('doit avoir un nom alpha numérique et une extension en ".md"', () => {
+        try {
+          expect(file).toMatch(/^[0-9a-z-_]+\.md$/)
+        }
+        catch {
+          throw new Error(
+            `Le nom du fichier ${file} doit être en minuscule, finir par l'extension '.md', ne pas contenir d'espace, d'accents ou de caractères spéciaux (sauf "-" et "_")`,
+          )
+        }
+      })
+
+      it('doit avoir un champ `title`', () => {
+        try {
+          expect(tutoFileMetadata.title).toBeDefined()
+          expect(typeof tutoFileMetadata.title).toBe('string')
+        }
+        catch {
+          throw new Error('Le champ "title" est obligatoire.')
+        }
+      })
+
+      it('doit avoir un champ `description`', () => {
+        try {
+          expect(tutoFileMetadata.description).toBeDefined()
+          expect(typeof tutoFileMetadata.description).toBe('string')
+        }
+        catch {
+          throw new Error('Le champ "description" est obligatoire.')
+        }
+      })
+
+      it('doit avoir un champ `videoEmbedSrc`', () => {
+        try {
+          expect(tutoFileMetadata.videoEmbedSrc).toBeDefined()
+        }
+        catch {
+          throw new Error('Le champ "videoEmbedSrc" est obligatoire.')
+        }
+      })
+
+      it('doit avoir un champ `captionFilePath`', () => {
+        try {
+          expect(tutoFileMetadata.captionFilePath).toBeDefined()
+        }
+        catch {
+          throw new Error('Le champ "captionFilePath" est obligatoire.')
+        }
+      })
+
+      it('ne doit pas contenir des champs inconnus', () => {
+        const acceptedFields = [
+          'title',
+          'description',
+          'videoEmbedSrc',
+          'captionFilePath',
+        ]
+
+        try {
+          expect(acceptedFields).toEqual(
+            expect.arrayContaining(Object.keys(tutoFileMetadata)),
+          )
+        }
+        catch {
+          throw new Error(
+              `Des champs inconnus sont présents. Champs attendus : ${acceptedFields}.`,
+          )
+        }
+      })
+
+      it('le champ `videoEmbedSrc` doit avoir un format précis', () => {
+        try {
+          expect(tutoFileMetadata.videoEmbedSrc).toMatch(
+            /^https:\/\/videos\.pix\.fr\/tutos\/sixieme\/(\w|-)+\.mp4$/,
+          )
+        }
+        catch {
+          throw new Error(
+            `Le format du lien "videoEmbedSrc" est invalide (format attendu : "https://videos.pix.fr/tutos/sixieme/{ID_VIDEO}.mp4", valeur reçue : "${
+              tutoFileMetadata.videoEmbedSrc ?? ''
+            }")`,
+          )
+        }
+      })
+    })
+  })
+})


### PR DESCRIPTION
## :unicorn: Problème
On doit donner accès à des vidéos pour les sixièmes. Il faut qu'ils puissent y accéder jeudi matin de cette semaine.

## :robot: Proposition
Ajouter les pages nécessaires au bon fonctionnement de Pix Tutos. Elles apparaissent maintenant dans `/sixieme`.

## :rainbow: Remarques
J'ai initié un layout `sixieme` qui est un copié collé de celui de la `mednum`. Peut-être faudrait-il faire un layout plus générique ?

## :100: Pour tester
Vérifier qu'on peut accéder à une capsule vidéo dans `/sixieme`.
