### PR TITLE
[TECH] Retirer l'appel au CDN de Plyr (PIX-10561)

### DIFF
--- a/components/PixVideoPlayer.vue
+++ b/components/PixVideoPlayer.vue
@@ -1,5 +1,6 @@
 <script setup>
 import player_fr from 'assets/translation/player_fr'
+import plyrSprites from 'plyr/dist/plyr.svg'
 import Plyr from 'plyr'
 
 defineProps({
@@ -20,7 +21,13 @@ defineProps({
 const video = ref(null)
 onMounted(() => {
   // eslint-disable-next-line no-new
-  new Plyr(video.value, { hideControls: false, disableContextMenu: false, i18n: player_fr })
+  new Plyr(video.value, {
+    hideControls: false,
+    disableContextMenu: false,
+    i18n: player_fr,
+    loadSprite: false,
+    iconUrl: plyrSprites,
+  })
 })
 </script>
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,6 @@ services:
       - /etc/nginx/logs
     volumes:
       - ./nginx.conf:/etc/nginx/conf.d/default.conf
-      - ./dist:/app/dist
+      - ./.output:/app/.output
     ports:
       - 80:80


### PR DESCRIPTION
## :christmas_tree: Problème
Plyr par defaut appel au CDN (cloudfare) pour telecharger les icons.

## :gift: Proposition
Retirer l'appel au CDN et loader les icon de `node_modules`

## :socks: Remarques


## :santa: Pour tester
Aller [ici](https://pix-tutos-review-pr267.osc-fr1.scalingo.io/mednum/interagir-avec-une-visualisation) et verifier qu'il n y a pas un appel vers le CDN 
