### PR TITLE
[TECH] Regrouper les montées de version Node

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,7 @@ version: 2.0
 jobs:
   test:
     docker:
+      # renovate datasource=node-version depName=node
       - image: cimg/node:20.16.0
     steps:
       - checkout


### PR DESCRIPTION
## :unicorn: Problème
Node.js ne se met pas à jour partout au même moment entre : 
- Circle CI
- .npmrc
- package.json

## :robot: Proposition
De [la même manière qu'ailleurs](https://github.com/1024pix/pix-ui/blob/053f1d16566aa99815e4911bc65112aee4336a62/.circleci/config.yml#L9C20-L10C56), faire en sorte que les montées de version de Node soit groupées.

## :rainbow: Remarques
RAS

## :100: Pour tester
🤷 
