### PR TITLE
[TECH] Regrouper les montées de version Node

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,30 @@
----
-version: 2.0
+version: 2.1
+
+orbs:
+  browser-tools: circleci/browser-tools@1.4.8
+
+executors:
+  node:
+    parameters:
+      node-version:
+        # renovate datasource=node-version depName=node
+        default: 20.16.0
+        type: string
+    docker:
+      - image: cimg/node:<<parameters.node-version>>
+  playwright:
+    parameters:
+      playwright-version:
+        # renovate datasource=npm depName=@playwright/test
+        default: 1.45.3
+        type: string
+    docker:
+      - image: mcr.microsoft.com/playwright:v<<parameters.playwright-version>>
+    resource_class: medium
 
 jobs:
   test:
-    docker:
-      # renovate datasource=node-version depName=node
-      - image: cimg/node:20.16.0
+    executor: node
     steps:
       - checkout
       - run: cat package*.json > cachekey
@@ -27,9 +46,7 @@ jobs:
             npm run test
 
   e2e:
-    docker:
-      - image: mcr.microsoft.com/playwright:v1.45.3-focal
-    resource_class: medium
+    executor: playwright
     steps:
       - checkout
       - run: cat package*.json > cachekey


### PR DESCRIPTION
## :unicorn: Problème
Node.js ne se met pas à jour partout au même moment entre : 
- Circle CI
- .npmrc
- package.json

## :robot: Proposition
De [la même manière qu'ailleurs](https://github.com/1024pix/pix-ui/blob/053f1d16566aa99815e4911bc65112aee4336a62/.circleci/config.yml#L9C20-L10C56), faire en sorte que les montées de version de Node soit groupées.

## :rainbow: Remarques
Suite de #347

## :100: Pour tester
🤷 
