### PR TITLE
[TECH] Ajoute un calculateur de taille de bundle

### DIFF
--- a/.github/workflows/compressed-size.yaml
+++ b/.github/workflows/compressed-size.yaml
@@ -1,0 +1,17 @@
+name: Calculate bundle size
+
+on: [pull_request]
+
+jobs:
+  calculate-bundle-size:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: package.json
+          registry-url: https://registry.npmjs.org/
+      - uses: preactjs/compressed-size-action@v2
+        with:
+          pattern: '.output/public/**'


### PR DESCRIPTION
## :robot: Proposition
Pour suivre les évolutions de taille de bundle, on peut utiliser [compressed-size-action](https://github.com/preactjs/compressed-size-action). Essayer :) 
