### PR TITLE
[FEATURE] Ajout de lien de téléchargement manquant

### DIFF
--- a/content/edu/accompagner-les-eleves-a-la-maitrise-de-leur-identite-numerique.md
+++ b/content/edu/accompagner-les-eleves-a-la-maitrise-de-leur-identite-numerique.md
@@ -3,7 +3,7 @@ area: Domaine 5
 title: Accompagner les élèves à la maîtrise de leur identité numérique
 description: À partir du collège, la plupart des élèves commencent à utiliser Internet et les réseaux sociaux. L’ensemble des traces qu’ils laissent, volontairement ou non, construit petit à petit leur identité numérique. Faisons donc un point sur l’identité numérique et voyons comment accompagner les élèves à la maîtriser ?
 videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/e2626989-7aff-46a3-a38c-d4aa11b5d58e
-videoDownloadHref:
+videoDownloadHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/e2626989-7aff-46a3-a38c-d4aa11b5d58e-1080-fragmented.mp4
 ---
 
 ## Transcription

--- a/content/edu/connaitre-des-supports-educatifs-ludiques-numeriques.md
+++ b/content/edu/connaitre-des-supports-educatifs-ludiques-numeriques.md
@@ -3,7 +3,7 @@ area: Domaine 4
 title: Connaître des supports éducatifs ludiques numériques
 description: "Devinette ! Qui a dit : « Le jeu c’est le travail de l’enfant, c’est son métier, c’est sa vie ! » ? Réponse : Pauline Kergomard, fondatrice des écoles maternelles, au début du siècle dernier. Car oui, jouer développe les capacités sensorielles, psychomotrices, intellectuelles, sociales, affectives. Mais quels sont les mécanismes ludiques à connaître ? Quelles ressources mobiliser ?"
 videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/da8bfe0a-ee36-4f50-a7c3-11d0d4e21141
-videoDownloadHref:
+videoDownloadHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/da8bfe0a-ee36-4f50-a7c3-11d0d4e21141-1080-fragmented.mp4
 ---
 
 ## Transcription

--- a/content/edu/eduquer-aux-donnees-pour-developper-des-communs.md
+++ b/content/edu/eduquer-aux-donnees-pour-developper-des-communs.md
@@ -3,7 +3,7 @@ area: Domaine 5
 title: Éduquer aux données pour développer des communs
 description: Si les données font aujourd’hui partie intégrante de nos vies, il est indispensable de comprendre comment celles-ci sont produites et comment les mettre au service de l’intérêt général. Alors, quels sont les enjeux de l’éducation aux données ? Et comment les données ouvertes peuvent-elles contribuer à l’intérêt général ?
 videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/72df3b53-b82f-46d9-bd12-b84173ddb517
-videoDownloadHref:
+videoDownloadHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/72df3b53-b82f-46d9-bd12-b84173ddb517-1080-fragmented.mp4
 ---
 
 ## Transcription

--- a/content/edu/le-bien-etre-numerique.md
+++ b/content/edu/le-bien-etre-numerique.md
@@ -3,7 +3,7 @@ area: Domaine 5
 title: Le bien-être numérique
 description: L’exposition soutenue aux écrans peut avoir des conséquences sur la santé physique et mentale des jeunes comme des adultes. Dans un contexte où les entreprises du numérique veulent toujours plus notre temps d’attention, quels sont les effets d’une surexposition aux écrans sur la santé physique et mentale ? Comment sensibiliser à l’économie de l’attention ?
 videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/e2019138-fd8b-4be9-a6bb-1e940d9e10a8
-videoDownloadHref:
+videoDownloadHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/e2019138-fd8b-4be9-a6bb-1e940d9e10a8-1080-fragmented.mp4
 ---
 
 ## Transcription

--- a/content/edu/les-acteurs-institutionnels-du-numerique-educatif-dans-le-1er-degre.md
+++ b/content/edu/les-acteurs-institutionnels-du-numerique-educatif-dans-le-1er-degre.md
@@ -3,7 +3,7 @@ area: Domaine 1
 title: Les acteurs institutionnels du numérique éducatif dans le 1er degré
 description: eRUN, CPD numérique, IEN numérique, DRAN... Ils sont nombreux à contribuer au développement du numérique éducatif dans le premier degré. Mais quels sont les rôles spécifiques de chacun ? Découvrons ensemble le « Qui fait quoi » du numérique éducatif au premier degré
 videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/f87f764b-5b4e-4219-a731-4e74cda01f25
-videoDownloadHref:
+videoDownloadHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/f87f764b-5b4e-4219-a731-4e74cda01f25-1080-fragmented.mp4
 ---
 
 ## Transcription

--- a/content/edu/les-banques-de-ressources-pedagogiques-en-ligne.md
+++ b/content/edu/les-banques-de-ressources-pedagogiques-en-ligne.md
@@ -3,7 +3,7 @@ area: Domaine 2
 title: Les banques de ressources pédagogiques en ligne
 description: Quels sont les types de banques de ressources permettant d’enrichir ses cours ? Comment identifier la banque pertinente ? Comment analyser et intégrer les ressources identifiées à vos cours ?
 videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/849833a8-0486-4661-b8b5-d5215dd5fd10
-videoDownloadHref:
+videoDownloadHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/849833a8-0486-4661-b8b5-d5215dd5fd10-1080-fragmented.mp4
 ---
 
 ## Transcription

--- a/content/edu/les-femmes-dans-les-metiers-du-numerique.md
+++ b/content/edu/les-femmes-dans-les-metiers-du-numerique.md
@@ -3,7 +3,7 @@ area: Domaine 5
 title: Les femmes dans les métiers du numérique
 description: Les métiers du numérique connaissent aujourd’hui une sous-représentation féminine. Pourtant, cela n’a pas toujours été le cas ! Mais alors, qui étaient les femmes pionnières du numérique ? D’où vient cette sous-représentation féminine ? Quelles en sont les conséquences ? Et quelles solutions existent pour y remédier ?
 videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/e76a5d71-95fb-4ed4-bc2e-af6c4dc47209
-videoDownloadHref:
+videoDownloadHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/e76a5d71-95fb-4ed4-bc2e-af6c4dc47209-1080-fragmented.mp4
 ---
 
 ## Transcription

--- a/content/edu/les-groupes-thematiques-numeriques-gtnum.md
+++ b/content/edu/les-groupes-thematiques-numeriques-gtnum.md
@@ -3,7 +3,7 @@ area: Domaine 1
 title: Les Groupes thématiques numériques (GTnum)
 description: La Direction du numérique pour l’éducation apporte son soutien financier à des projets de recherche sur les thématiques de l’éducation et du numérique. Que sont les GTnum, quels sont leurs objectifs et comment accéder à leurs productions ?
 videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/1b9c4b3c-55fd-4f87-979b-ccf30c5ce44e
-videoDownloadHref:
+videoDownloadHref: https://tube.reseau-canope.fr/download/videos/1b9c4b3c-55fd-4f87-979b-ccf30c5ce44e-1080.mp4
 ---
 
 ## Transcription

--- a/content/edu/les-impacts-ecologiques-du-numerique.md
+++ b/content/edu/les-impacts-ecologiques-du-numerique.md
@@ -3,7 +3,7 @@ area: Domaine 5
 title: Les impacts écologiques du numérique
 description: Le numérique est loin d’être un espace dématérialisé. Il implique un tas d’objets physiques qui consomment beaucoup de matières premières, d’énergie, d’espace et qui ont un impact fort sur l’environnement. Il est donc nécessaire de sensibiliser ses élèves et de prendre en compte cet enjeu sociétal dans nos usages individuels et collectifs.
 videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/e5d3d493-1bc9-4b88-a6ba-0cc046b80316
-videoDownloadHref:
+videoDownloadHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/e5d3d493-1bc9-4b88-a6ba-0cc046b80316-1080-fragmented.mp4
 ---
 
 ## Transcription

--- a/content/edu/les-modeles-economiques-du-numerique.md
+++ b/content/edu/les-modeles-economiques-du-numerique.md
@@ -3,7 +3,7 @@ area: Domaine 5
 title: Les modèles économiques du numérique
 description: Les sites et applications nous proposent beaucoup de services, et en apparence… gratuitement ! Pourtant, la plupart de ces plateformes sont très rentables et il est important de comprendre comment. Alors, quels sont ces différents modèles économiques du numérique ? Et quelles ressources pour aborder ce sujet avec les élèves ?
 videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/4935978f-5673-4276-a540-9552f5719e2a
-videoDownloadHref:
+videoDownloadHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/4935978f-5673-4276-a540-9552f5719e2a-1080-fragmented.mp4
 ---
 
 ## Transcription

--- a/content/edu/mettre-a-disposition-et-partager-des-ressources-a-des-pairs-2nd-degre.md
+++ b/content/edu/mettre-a-disposition-et-partager-des-ressources-a-des-pairs-2nd-degre.md
@@ -3,7 +3,7 @@ area: Domaine 2
 title: Mettre à disposition et partager des ressources à des pairs, 2nd degré
 description: Quels canaux utiliser pour partager sans risque ses productions ? Quelles sont les règles à respecter ?
 videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/cb693c5d-c66b-4aed-be9b-9213196d0a01
-videoDownloadHref:
+videoDownloadHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/cb693c5d-c66b-4aed-be9b-9213196d0a01-1080-fragmented.mp4
 ---
 
 ## Transcription

--- a/content/edu/outils-pour-differencier-grace-au-numerique.md
+++ b/content/edu/outils-pour-differencier-grace-au-numerique.md
@@ -3,7 +3,7 @@ area: Domaine 4
 title: Outils pour différencier grâce au numérique
 description: Comment repérer les besoins des élèves, comment adapter son enseignement en termes de contenu, structure, processus, production et avec l'aide de quels outils numériques ?
 videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/7447b1eb-46cc-4942-a264-801dbe24fb69
-videoDownloadHref:
+videoDownloadHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/7447b1eb-46cc-4942-a264-801dbe24fb69-1080-fragmented.mp4
 ---
 
 ## Transcription

--- a/content/edu/realite-augmentee-et-realite-virtuelle-au-service-des-apprentissages.md
+++ b/content/edu/realite-augmentee-et-realite-virtuelle-au-service-des-apprentissages.md
@@ -3,7 +3,7 @@ area: Domaine 4
 title: Réalité augmentée et réalité virtuelle au service des apprentissages
 description: Réalité augmentée et réalité virtuelle repoussent les limites de la classe. Mais quelle différence entre virtuelle et augmentée ? Et quels intérêts pédagogiques pour ces nouvelles technologies ?
 videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/5ef21c8d-a0c5-48c7-a68b-fd8dc2d9dda3
-videoDownloadHref:
+videoDownloadHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/5ef21c8d-a0c5-48c7-a68b-fd8dc2d9dda3-1080-fragmented.mp4
 ---
 
 ## Transcription

--- a/content/edu/recherche-sur-internet-bulles-de-filtres-et-desinformation.md
+++ b/content/edu/recherche-sur-internet-bulles-de-filtres-et-desinformation.md
@@ -3,7 +3,7 @@ area: Domaine 5
 title: Recherche sur Internet, bulles de filtres et désinformation
 description: Comment fonctionne un moteur de recherche ? Pourquoi des résultats différents par utilisateur ? Pourquoi n’avons-nous pas accès aux mêmes actualités sur les réseaux sociaux ? Comment s’assurer de la fiabilité des informations ?
 videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/0964d468-16b3-4045-93bc-d3ac22144d3e
-videoDownloadHref:
+videoDownloadHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/0964d468-16b3-4045-93bc-d3ac22144d3e-1080-fragmented.mp4
 ---
 
 ## Transcription

--- a/content/edu/utiliser-et-creer-des-supports-educatifs-ludiques-numeriques.md
+++ b/content/edu/utiliser-et-creer-des-supports-educatifs-ludiques-numeriques.md
@@ -3,7 +3,7 @@ area: Domaine 4
 title: Utiliser et créer des supports éducatifs ludiques numériques
 description: Et si on utilisait les ressorts du jeu pour motiver les élèves à apprendre. Comment préparer et mener une activité ludopédagogique ? Où trouver des supports ludiques, quels outils pour en créer ?
 videoEmbedSrc: https://tube.reseau-canope.fr/videos/embed/482b1299-3cf9-48c3-9f1a-d1e97b4fd750
-videoDownloadHref:
+videoDownloadHref: https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/482b1299-3cf9-48c3-9f1a-d1e97b4fd750-1080-fragmented.mp4
 ---
 
 ## Transcription

--- a/tests/unit/verify-edu-content.test.js
+++ b/tests/unit/verify-edu-content.test.js
@@ -21,7 +21,7 @@ describe('verification du contenu dans le dossier `content/edu`', () => {
       }
     })
 
-    describe(`le fichier `, () => {
+    describe(`le fichier ${file}`, () => {
       it('doit avoir un nom alpha numérique et une extension en ".md"', () => {
         try {
           expect(file).toMatch(/^[0-9a-z-_]+\.md$/)

--- a/tests/unit/verify-edu-content.test.js
+++ b/tests/unit/verify-edu-content.test.js
@@ -123,12 +123,12 @@ describe('verification du contenu dans le dossier `content/edu`', () => {
           return
         try {
           expect(tutoFileMetadata.videoDownloadHref).toMatch(
-            /^https:\/\/tube\.reseau-canope\.fr\/download\/streaming-playlists\/hls\/videos\/(\w|-)+\.mp4$/,
+            /^https:\/\/tube\.reseau-canope\.fr\/download\/(streaming-playlists\/hls\/)?videos\/(\w|-)+\.mp4$/,
           )
         }
         catch {
           throw new Error(
-            `Le format du lien "videoDownloadHref" est invalide (format attendu : "https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/{ID_VIDEO}.mp4", valeur reçue : "${tutoFileMetadata.videoDownloadHref}")`,
+            `Le format du lien "videoDownloadHref" est invalide (format attendu : "https://tube.reseau-canope.fr/download/streaming-playlists/hls/videos/{ID_VIDEO}.mp4" ou "https://tube.reseau-canope.fr/download/videos/{ID_VIDEO}.mp4", valeur reçue : "${tutoFileMetadata.videoDownloadHref}")`,
           )
         }
       })


### PR DESCRIPTION
## :unicorn: Problème
Il manquait des liens de téléchargement sur une 15aine de tutoriels +Edu by Canopé
## :robot: Proposition
Ajout

## :rainbow: Remarques
Absence de lien détectée en cherchant
`videoDownloadHref: ---`
## :100: Pour tester
Sur les pages modifiées, voir si le bouton téléchargement est bien présent et mène au bout lien