### PR TITLE
[TECH] Remplacer Jean Pierre par le bouton de merge natif

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -16,6 +16,5 @@ jobs:
   automerge:
     runs-on: ubuntu-latest
     steps:
-      - uses: 1024pix/pix-actions/auto-merge@v0
-        with:
-          auto_merge_token: '${{ secrets.PIX_SERVICE_ACTIONS_TOKEN }}'
+      - run: echo 'Automerge has been deactivated on pix-tutos, please use native GitHub Merge button'
+      - run: exit 1


### PR DESCRIPTION
## :unicorn: Problème
Aujourd’hui la plupart des projets Pix utilisent le tag GitHub “🚀 Ready to merge” qui déclenche le bot “Jean Pierre Pernault” AKA pix-auto-merge qui s’assure que la PR soit à jour. Si elle ne l’est pas, Jean Pierre lance un rebase sans fast-forward et relance la CI avant de merger la PR.

## :robot: Proposition
Expérimenter l'usage des fonctionnalités natives de GitHub.

## :100: Pour tester
Déclencher Jean Pierre et voir le résultat.
