### PR TITLE
Revert "[TECH] Remplacer Jean Pierre par le bouton de merge natif"

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -16,5 +16,6 @@ jobs:
   automerge:
     runs-on: ubuntu-latest
     steps:
-      - run: echo 'Automerge has been deactivated on pix-tutos, please use native GitHub Merge button'
-      - run: exit 1
+      - uses: 1024pix/pix-actions/auto-merge@v0
+        with:
+          auto_merge_token: '${{ secrets.PIX_SERVICE_ACTIONS_TOKEN }}'


### PR DESCRIPTION
Reverts 1024pix/pix-tutos#366

Il semblerait que le squash & merge ne fonctionne pas pour générer une release auto. Voir https://github.com/1024pix/conventional-changelog-pix/pull/46